### PR TITLE
prevent duplicate eliminations

### DIFF
--- a/app.py
+++ b/app.py
@@ -412,11 +412,15 @@ def eliminate_card():
     if not card_id:
         return jsonify({"status": "error", "message": "card_id required"}), 400
 
-    record_event("player2", "eliminate", game_id, card=card_id)
+    # Check if card is already eliminated
     eliminated = get_eliminated_cards(game_id)
+    if int(card_id) in eliminated:
+        return jsonify({"status": "ok"})  # Already eliminated, no action needed
+
+    record_event("player2", "eliminate", game_id, card=card_id)
     socketio.emit(
         "eliminate",
-        {"card": int(card_id), "eliminated": list(eliminated)},
+        {"card": int(card_id)},
         to=f"game:{game_id}",
     )
     print(f"Game {game_id}: card {card_id} eliminated")

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -119,12 +119,9 @@
             appendMessage(`<em>${data.role || "System"} joined game ${data.game_id}</em>`, "color:gray;");
         });
         socket.on("eliminate", data => {
-            const eliminatedIds = data.eliminated || [];
-            appendMessage(`<em>Eliminated cards: ${eliminatedIds.join(", ")}</em>`, "color:red;");
-            eliminatedIds.forEach(id => {
-                const cardEl = document.getElementById(`card${id}`);
-                if (cardEl) cardEl.classList.add("eliminated");
-            });
+            appendMessage(`<em>Eliminated card: ${data.card}</em>`, "color:red;");
+            const cardEl = document.getElementById(`card${data.card}`);
+            if (cardEl) cardEl.classList.add("eliminated");
         });
 
         // --- Voice (WebRTC) -------------------------------------------

--- a/templates/player1.html
+++ b/templates/player1.html
@@ -95,9 +95,7 @@
             appendMessage(`<em>${data.role || 'System'} joined game ${data.game_id}</em>`, 'color:gray;');
         });
 
-        socket.on('eliminate', data => {
-            appendMessage(`<em>Player 2 eliminated card ${data.card}</em>`, 'color:red;');
-        });
+        // Player 1 does not receive elimination messages - only moderator and player2 should see them
 
         // --- Voice (WebRTC) -------------------------------------------
         setupVoice({

--- a/templates/player2.html
+++ b/templates/player2.html
@@ -100,6 +100,11 @@
 
         // --- Elimination logic -----------------------------------------
         function eliminateCard(cardId) {
+            const cardEl = document.getElementById(`card${cardId}`);
+            // Prevent eliminating the same card twice
+            if (cardEl && cardEl.classList.contains('eliminated')) {
+                return;
+            }
             fetch('/eliminate_card', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
@@ -108,12 +113,9 @@
         }
 
         socket.on('eliminate', data => {
-            const eliminatedIds = data.eliminated || [];
-            appendMessage(`<em>Eliminated cards: ${eliminatedIds.join(', ')}</em>`, 'color:red;');
-            eliminatedIds.forEach(id => {
-                const cardEl = document.getElementById(`card${id}`);
-                if (cardEl) cardEl.classList.add('eliminated');
-            });
+            appendMessage(`<em>Eliminated card: ${data.card}</em>`, 'color:red;');
+            const cardEl = document.getElementById(`card${data.card}`);
+            if (cardEl) cardEl.classList.add('eliminated');
         });
 
         // --- Voice (WebRTC) -------------------------------------------


### PR DESCRIPTION
Fixes #21 
Fixes #27 

- Prevent duplicate eliminations on the client and server to avoid extra DB records and broadcasts.
- Emit only the single eliminated card in real-time updates (no full list).
-  Player 1 cannot see what cards are eliminated

 