### PR TITLE
feat: implement single-use token-based access control for participants

### DIFF
--- a/docs/TOKEN_SYSTEM.md
+++ b/docs/TOKEN_SYSTEM.md
@@ -1,0 +1,245 @@
+# Token-Based Invitation System
+
+## Overview
+
+The GuessWho Stereotype game now implements a secure, single-use invitation token system for participant access. This replaces the previous open entry system and provides better control over participant management.
+
+## Key Features
+
+### 1. **Single-Use Invitation Tokens**
+- Moderator generates unique, unguessable tokens for each participant
+- Each token can only be redeemed once
+- Tokens are bound to specific games but not to personal identity
+- Format: `https://<host>/join?token=<uuid>`
+
+### 2. **Persistent Participant Identifiers**
+- Upon token redemption, a unique participant ID is created
+- Participant ID persists throughout the session (stored in session cookie)
+- Allows participants to complete both roles within the same game session
+
+### 3. **Role Assignment Flow**
+- Participant redeems token → enters waiting room
+- Moderator assigns role (player1/player2) dynamically
+- Real-time notification via SocketIO when role is assigned
+- Automatic redirect to appropriate game view
+
+### 4. **Role Switching**
+- Moderator can switch participant roles mid-session
+- Useful for allowing participants to experience both perspectives
+- Immediate notification and redirect upon role switch
+
+## Database Schema
+
+### invitation_tokens
+```sql
+CREATE TABLE invitation_tokens (
+    token TEXT PRIMARY KEY,
+    game_id TEXT,
+    created_at TEXT,
+    used_at TEXT,           -- NULL until redeemed
+    participant_id TEXT,    -- Set when redeemed
+    UNIQUE(token)
+)
+```
+
+### participants
+```sql
+CREATE TABLE participants (
+    id TEXT PRIMARY KEY,
+    created_at TEXT,
+    last_seen TEXT
+)
+```
+
+### participant_bindings (existing, enhanced)
+```sql
+CREATE TABLE participant_bindings (
+    game_id TEXT,
+    participant_id TEXT,
+    role TEXT,
+    created_at TEXT,
+    PRIMARY KEY (game_id, participant_id)
+)
+```
+
+## API Endpoints
+
+### Moderator Endpoints
+
+#### `POST /api/generate_token`
+Generate a new invitation token.
+
+**Request:**
+```json
+{
+    "game_id": "abc123...",
+    "email": "participant@example.com"  // optional, for reference only
+}
+```
+
+**Response:**
+```json
+{
+    "status": "ok",
+    "token": "def456...",
+    "join_url": "https://host/join?token=def456..."
+}
+```
+
+#### `POST /api/assign_role`
+Assign a role to a waiting participant.
+
+**Request:**
+```json
+{
+    "participant_id": "p123...",
+    "role": "player1",  // or "player2"
+    "game_id": "abc123..."
+}
+```
+
+#### `POST /api/switch_role`
+Switch a participant's role mid-session.
+
+**Request:**
+```json
+{
+    "participant_id": "p123...",
+    "new_role": "player2",
+    "game_id": "abc123..."
+}
+```
+
+#### `GET /api/waiting_participants?game_id=<id>`
+Get list of participants in waiting room.
+
+**Response:**
+```json
+{
+    "status": "ok",
+    "waiting_participants": [
+        {
+            "id": "p123...",
+            "created_at": "2026-02-09T...",
+            "last_seen": "2026-02-09T...",
+            "used_at": "2026-02-09T..."
+        }
+    ],
+    "assigned_count": 0
+}
+```
+
+#### `GET /api/assigned_participants?game_id=<id>`
+Get list of participants with assigned roles.
+
+### Participant Endpoints
+
+#### `GET /join?token=<token>`
+Redeem invitation token and enter waiting room.
+
+- Validates token exists and is unused
+- Creates persistent participant ID
+- Marks token as used
+- Stores participant_id in session
+- Redirects to `/waiting?participant_id=<id>`
+
+#### `GET /waiting?participant_id=<id>`
+Waiting room for participants.
+
+- Displays waiting status
+- Listens for role assignment via SocketIO
+- Auto-redirects to game view when role is assigned
+
+## SocketIO Events
+
+### `join_participant_room`
+Join a participant-specific room for notifications.
+
+**Client → Server:**
+```json
+{
+    "participant_id": "p123..."
+}
+```
+
+### `role_assigned`
+Notification when moderator assigns a role.
+
+**Server → Client:**
+```json
+{
+    "role": "player1",
+    "game_id": "abc123..."
+}
+```
+
+### `role_switched`
+Notification when moderator switches participant's role.
+
+**Server → Client:**
+```json
+{
+    "new_role": "player2",
+    "game_id": "abc123..."
+}
+```
+
+## Usage Flow
+
+### Research Session Setup
+
+1. **Moderator logs in** (`/login`)
+2. **Access control panel** (`/dashboard` → "Open Control Panel")
+3. **Generate invitation tokens**:
+   - Enter participant email (optional, for reference)
+   - Click "Generate Token"
+   - Copy invitation URL
+   - Send via email or other channel
+4. **Monitor waiting room**:
+   - See participants as they redeem tokens
+   - Waiting participants appear in "⏳ Waiting Participants" section
+5. **Assign roles**:
+   - Click "🎭 Player 1" or "🔍 Player 2" for each participant
+   - Participants are automatically redirected to their role view
+6. **Monitor game**:
+   - Use moderator observer view to watch gameplay
+   - Switch roles mid-session if needed
+7. **End session**:
+   - Game data is logged to database
+   - Generate new tokens for next pair of participants
+
+### Participant Experience
+
+1. **Receive invitation email** with join URL
+2. **Click link** → Token validation
+3. **Enter waiting room** → "Waiting for role assignment..."
+4. **Role assigned** → Automatic redirect to game view
+5. **Play game** in assigned role
+6. **Role switched** (optional) → Automatic redirect to new role view
+
+## Security Features
+
+- **Unguessable tokens**: UUIDv4 tokens (128-bit randomness)
+- **Single-use**: Token marked as used after first redemption
+- **No personal binding**: Tokens not tied to email/identity
+- **Session persistence**: participant_id stored in secure session cookie
+- **Moderator authentication**: All token operations require moderator login
+
+## Email as Delivery Channel
+
+Email is used **solely as a delivery channel** for invitation links. The system:
+- Does NOT verify email addresses
+- Does NOT store email as identity
+- Does NOT require email to join (direct link access works)
+- Optionally logs email for moderator reference only
+
+This approach ensures participant anonymity while providing a convenient distribution mechanism.
+
+## Migration Notes
+
+This system coexists with the existing "Quick Game Mode" which generates pre-assigned participant URLs. The two modes are:
+
+1. **Token-Based Mode** (New): Moderator control panel with dynamic role assignment
+2. **Quick Game Mode** (Legacy): Instant game creation with pre-generated URLs
+
+Both modes use the same database schema and game logic.

--- a/templates/moderator_control.html
+++ b/templates/moderator_control.html
@@ -174,7 +174,8 @@
         <div class="info-section">
             <h3>📋 Instructions</h3>
             <ol>
-                <li><strong>Open Entry:</strong> Allow participants to join via the static join URL</li>
+                <li><strong>Generate Tokens:</strong> Create invitation links for participants</li>
+                <li><strong>Open Entry:</strong> Allow participants to join via their unique links</li>
                 <li><strong>Wait:</strong> Exactly 2 participants must join (entry auto-closes)</li>
                 <li><strong>Start Game:</strong> Roles are assigned automatically and participants are redirected</li>
                 <li><strong>End Game:</strong> When game concludes, end the session</li>
@@ -182,13 +183,21 @@
             </ol>
         </div>
 
-        <div class="info-section" id="join-url-section" style="display: none;">
-            <h3>🔗 Static Join URL</h3>
-            <p>Share this URL with participants in advance:</p>
-            <div class="url-box" id="join-url" onclick="copyJoinUrl()">
-                Loading...
+        <div class="info-section">
+            <h3>🎟️ Generate Access Tokens</h3>
+            <p>Create unique invitation links for participants (valid for 30 days):</p>
+            <div style="display: flex; gap: 10px; align-items: center; margin-top: 15px;">
+                <label for="token-count">Number of tokens:</label>
+                <input type="number" id="token-count" min="1" max="100" value="10" 
+                       style="padding: 8px; width: 80px; border: 1px solid #ddd; border-radius: 4px;">
+                <button id="btn-generate-tokens" class="control-btn btn-open" 
+                        style="flex: initial; min-width: 180px;">
+                    🎟️ Generate & Download
+                </button>
             </div>
-            <small>Click to copy to clipboard</small>
+            <small style="color: #666; margin-top: 10px; display: block;">
+                Tokens are single-use and include a unique join URL. Download as CSV for distribution.
+            </small>
         </div>
 
         <div class="info-section" id="participant-section" style="display: none;">
@@ -213,22 +222,6 @@
     <script>
         let currentState = null;
         let currentGameId = null;
-
-        // Set join URL
-        const joinUrl = window.location.origin + '/join';
-        document.getElementById('join-url').textContent = joinUrl;
-        document.getElementById('join-url-section').style.display = 'block';
-
-        function copyJoinUrl() {
-            navigator.clipboard.writeText(joinUrl).then(() => {
-                const box = document.getElementById('join-url');
-                const originalBg = box.style.background;
-                box.style.background = '#4CAF50';
-                setTimeout(() => {
-                    box.style.background = originalBg;
-                }, 500);
-            });
-        }
 
         async function updateStatus() {
             try {
@@ -383,6 +376,45 @@
                     updateStatus();
                 } else {
                     alert('Failed to reset session');
+                }
+            } catch (err) {
+                alert('Error: ' + err.message);
+            }
+        };
+
+        document.getElementById('btn-generate-tokens').onclick = async () => {
+            const count = parseInt(document.getElementById('token-count').value);
+            
+            if (!count || count < 1 || count > 100) {
+                alert('Please enter a valid number of tokens (1-100)');
+                return;
+            }
+            
+            try {
+                const res = await fetch('/moderator/tokens/generate', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ count: count })
+                });
+                
+                if (res.ok) {
+                    // Trigger download
+                    const blob = await res.blob();
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `access_tokens_${new Date().toISOString().slice(0,19).replace(/:/g,'-')}.csv`;
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                    window.URL.revokeObjectURL(url);
+                    
+                    alert(`✅ Generated ${count} tokens! Check your downloads.`);
+                } else {
+                    const data = await res.json();
+                    alert('Failed to generate tokens: ' + (data.message || 'Unknown error'));
                 }
             } catch (err) {
                 alert('Error: ' + err.message);

--- a/templates/waiting.html
+++ b/templates/waiting.html
@@ -79,16 +79,24 @@
         <h1>🎮 GuessWho Stereotype</h1>
         <p>Welcome to the game session!</p>
 
+        {% if error %}
+        <div class="status-message status-closed">
+            ⚠️ {{ error }}
+        </div>
+        {% else %}
         <div id="status-display">
             <div class="spinner"></div>
             <p>Checking status...</p>
         </div>
 
         <button id="join-btn" class="join-btn" style="display: none;">Join Game</button>
+        {% endif %}
     </div>
 
+    {% if not error %}
     <script>
-        let participantId = localStorage.getItem('participant_id');
+        const TOKEN = "{{ token if token else '' }}";
+        let participantId = "{{ participant_id if participant_id else '' }}" || localStorage.getItem('participant_id');
         let checkInterval;
         let hasJoined = false;
 
@@ -169,7 +177,13 @@
             joinBtn.textContent = 'Joining...';
 
             try {
-                const res = await fetch('/join/enter', { method: 'POST' });
+                const res = await fetch('/join/enter', { 
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ token: TOKEN })
+                });
                 const data = await res.json();
 
                 if (data.status === 'ok') {
@@ -186,6 +200,19 @@
                         <p>Waiting for ${2 - data.waiting_count} more participant(s)...</p>
                     `;
                     joinBtn.style.display = 'none';
+                } else if (data.status === 'in_game') {
+                    // Token already used and participant in game
+                    participantId = data.participant_id;
+                    localStorage.setItem('participant_id', participantId);
+                    document.getElementById('status-display').innerHTML = `
+                        <div class="status-message status-open">
+                            🎮 Redirecting to your game...
+                        </div>
+                        <div class="spinner"></div>
+                    `;
+                    setTimeout(() => {
+                        window.location.href = `/${data.role}?game_id=${data.game_id}&participant_id=${participantId}`;
+                    }, 1000);
                 } else {
                     alert(data.message || 'Failed to join');
                     joinBtn.disabled = false;
@@ -203,6 +230,7 @@
         checkStatus();
         checkInterval = setInterval(checkStatus, 2000);  // Check every 2 seconds
     </script>
+    {% endif %}
 </body>
 
 </html>


### PR DESCRIPTION
Fix #41 

Replace unrestricted join access with invitation-only entry using cryptographically secure, single-use tokens. Moderators generate tokens via control panel, participants redeem tokens once to create persistent participant_id, maintaining existing role assignment and game flow.

## Problem Solved
- Previously, anyone with the join URL could enter the game without restriction
- No way to control or track who receives invitations
- No mechanism to prevent unauthorized access to sessions

## Solution
Moderators generate unique, time-limited invitation tokens that participants use to gain entry. Each token can only be redeemed once to create a persistent participant identity.

## Key Features

### Token Generation (Moderator)
- New endpoint: `POST /moderator/tokens/generate`
- Generates 1-100 cryptographically secure tokens per request (`secrets.token_urlsafe(32)`)
- Fixed 30-day expiration period
- Returns CSV file with ready-to-share invitation URLs
- UI integrated into moderator control panel

### Token Validation (Participant)
- `/join?token=...` validates tokens before entry
- Checks: token exists, not expired, not already used
- Clear error messages for invalid/expired/reused tokens
- Single-use enforcement prevents token reuse attacks

### Token Redemption
- First use: creates persistent `participant_id` + marks token as used
- Subsequent attempts: rejected with error
- `participant_id` stored in browser localStorage for session continuity
- Database tracking in new `access_tokens` table