### PR TITLE
remove default game id

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -183,31 +183,20 @@ class TestChat:
         assert len(chat_events) > 0
 
     def test_chat_without_game_id(self, socketio_client, reset_globals, create_test_game):
-        """Test chat without game_id uses default."""
-        from app import get_transcript, DEFAULT_GAME_ID
-        
+        """Test chat without game_id returns error."""
         player1_id = "player-1-uuid"
         
-        # Create game record in database first
-        create_test_game(DEFAULT_GAME_ID)
-        
-        socketio_client.emit('join', {
-            'game_id': DEFAULT_GAME_ID,
-            'role': 'player1',
-            'participant_id': player1_id
-        })
-        
-        # Send chat without explicit game_id (defaults to DEFAULT_GAME_ID)
-        socketio_client.emit('chat', {
+        # Send chat without game_id (should return error)
+        result = socketio_client.emit('chat', {
             'role': 'player1',
             'participant_id': player1_id,
-            'text': 'Default game message'
-        })
+            'text': 'Message without game_id'
+        }, callback=True)
         
-        # Should be logged to DEFAULT_GAME_ID
-        transcript = get_transcript(DEFAULT_GAME_ID)
-        # Should have join + chat events
-        assert len(transcript) >= 1
+        # Should return error response
+        if result:
+            assert result.get('status') == 'error'
+            assert 'game_id' in result.get('message', '').lower()
 
     def test_chat_event_logging_complete(self, socketio_client, reset_globals, create_test_game):
         """Test that chat events are fully logged with all metadata."""

--- a/tests/test_gameplay.py
+++ b/tests/test_gameplay.py
@@ -222,9 +222,11 @@ class TestGamePlay:
         client.post("/join/enter", json={"token": tokens[1]})
         client.post("/moderator/control/start", json={})
         
-        # Try to eliminate without game_id (will use DEFAULT_GAME_ID)
+        # Try to eliminate without game_id (should now fail - game_id required)
         res = client.post("/eliminate_card", json={"card_id": 5})
-        assert res.status_code == 200  # Uses default game
+        assert res.status_code == 400  # Should fail - game_id required
+        data = json.loads(res.data)
+        assert "game_id" in data.get("message", "").lower()
         
         # Try without card_id at all
         res = client.post("/eliminate_card", json={"game_id": game_id})


### PR DESCRIPTION
## Remove DEFAULT_GAME_ID fallback constant

### Summary
Removes the legacy `DEFAULT_GAME_ID` fallback and enforces `game_id` as a required parameter across all endpoints. This cleanup aligns the codebase with the current token-based architecture where `game_id` is always provided through proper user flows.

### Motivation
- The fallback was never used in normal operation (dead code)
- Token system guarantees `game_id` is present in all legitimate requests
- Explicit errors are better than silent fallbacks for debugging
- Reduces code complexity and potential edge cases

### Changes
- **Removed**: `DEFAULT_GAME_ID` constant definition
- **Updated**: All HTTP routes and Socket.IO handlers to validate `game_id` presence
- **Error handling**: Returns explicit 400/error responses when `game_id` is missing
- **Tests**: Updated to verify required parameter validation

### Impact
- ✅ No breaking changes for normal user flows (token-based joins, moderator dashboards)
- ✅ Clearer error messages when API calls are malformed
- ✅ Simplified codebase with one less global constant
- ✅ All tests passing

### Testing
- Verified all existing tests pass
- Added test coverage for missing `game_id` validation
- Confirmed normal game flow unchanged
