### PR TITLE
fix: prevent false game-end UI lockups from transient status/Redis gl…

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,7 +133,9 @@ def get_game_state(game_id):
     try:
         data = get_redis().hgetall(f"game:{game_id}:state")
         if not data:
-            return None
+            data = GAME_STATES.get(game_id)
+            if not data:
+                return None
         # Convert JSON fields and "null" sentinels
         if 'waiting_participants' in data:
             data['waiting_participants'] = json.loads(data['waiting_participants'])
@@ -149,12 +151,20 @@ def get_game_state(game_id):
         return data
     except Exception as e:
         print(f"Error getting game state: {e}")
-        return None
+        data = GAME_STATES.get(game_id)
+        if not data:
+            return None
+        if 'round_number' in data:
+            try:
+                data['round_number'] = int(data['round_number'])
+            except (TypeError, ValueError):
+                data['round_number'] = 1
+        return data
 
 def set_game_state(game_id, state_dict):
     """Store game state in Redis."""
+    GAME_STATES[game_id] = dict(state_dict)
     if not get_redis():
-        GAME_STATES[game_id] = state_dict
         return
     try:
         # Convert lists/dicts to JSON for storage, handle None values
@@ -173,8 +183,8 @@ def set_game_state(game_id, state_dict):
 
 def delete_game_state(game_id):
     """Delete game state from Redis."""
+    GAME_STATES.pop(game_id, None)
     if not get_redis():
-        GAME_STATES.pop(game_id, None)
         return
     try:
         get_redis().delete(f"game:{game_id}:state")
@@ -286,16 +296,16 @@ def get_current_session_game_id():
         return CURRENT_SESSION_GAME_ID
     try:
         game_id = get_redis().get("current_session_game_id")
-        return game_id
+        return game_id or CURRENT_SESSION_GAME_ID
     except Exception as e:
         print(f"Error getting current session game ID: {e}")
         return CURRENT_SESSION_GAME_ID
 
 def set_current_session_game_id(game_id):
     """Set the current session game ID."""
+    global CURRENT_SESSION_GAME_ID
+    CURRENT_SESSION_GAME_ID = game_id
     if not get_redis():
-        global CURRENT_SESSION_GAME_ID
-        CURRENT_SESSION_GAME_ID = game_id
         return
     try:
         if game_id is None:
@@ -994,27 +1004,17 @@ def game_status():
     
     if not game_id:
         return jsonify({"status": "error", "message": "game_id required"}), 400
-    
-    current_game_id = get_current_session_game_id()
-    if not current_game_id or not get_game_state(current_game_id):
+
+    game_state = get_game_state(game_id)
+    if not game_state:
         return jsonify({
             "state": "CLOSED",
             "is_player": False,
             "message": "This game session is no longer active"
         })
-    
-    # Only allow access to the current active session game
-    if game_id != current_game_id:
-        return jsonify({
-            "state": "CLOSED",
-            "is_player": False,
-            "message": "This game session is no longer active"
-        })
-    
-    game_state = get_game_state(current_game_id)
-    
+
     return jsonify({
-        "game_id": current_game_id,
+        "game_id": game_id,
         "state": game_state['state'],
         "is_player": participant_id in [game_state.get('player1_id'), game_state.get('player2_id')]
     })

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -86,6 +86,8 @@
         
         // Track game end state
         let gameEnded = false;
+        let consecutiveEndStateChecks = 0;
+        const END_STATE_CONFIRMATION_THRESHOLD = 3;
 
         // --- Load chat history on page load -------------------------------
         fetch(`/transcript?game_id=${gameId}&limit=200`)
@@ -117,6 +119,11 @@
                 const data = await res.json();
                 
                 if (data.state === 'ENDED' || data.state === 'CLOSED') {
+                    consecutiveEndStateChecks += 1;
+                    if (consecutiveEndStateChecks < END_STATE_CONFIRMATION_THRESHOLD) {
+                        return;
+                    }
+
                     if (!gameEnded) {
                         gameEnded = true;
                         // Disable interactions
@@ -152,6 +159,8 @@
                     if (gameStatusInterval) {
                         clearInterval(gameStatusInterval);
                     }
+                } else {
+                    consecutiveEndStateChecks = 0;
                 }
             } catch (err) {
                 console.error('Game status check failed:', err);

--- a/templates/player1.html
+++ b/templates/player1.html
@@ -77,6 +77,8 @@
 
         // --- Game Status Polling -----------------------------------------------
         let gameEnded = false;
+        let consecutiveEndStateChecks = 0;
+        const END_STATE_CONFIRMATION_THRESHOLD = 3;
         
         async function checkGameStatus() {
             try {
@@ -89,6 +91,11 @@
                 const data = await res.json();
                 
                 if (data.state === 'ENDED' || data.state === 'CLOSED') {
+                    consecutiveEndStateChecks += 1;
+                    if (consecutiveEndStateChecks < END_STATE_CONFIRMATION_THRESHOLD) {
+                        return;
+                    }
+
                     if (!gameEnded) {
                         gameEnded = true;
                         // Disable interactions
@@ -123,6 +130,8 @@
                     if (gameStatusInterval) {
                         clearInterval(gameStatusInterval);
                     }
+                } else {
+                    consecutiveEndStateChecks = 0;
                 }
             } catch (err) {
                 console.error('Game status check failed:', err);

--- a/templates/player2.html
+++ b/templates/player2.html
@@ -104,6 +104,8 @@
 
         // --- Game Status Polling -----------------------------------------------
         let gameEnded = false;
+        let consecutiveEndStateChecks = 0;
+        const END_STATE_CONFIRMATION_THRESHOLD = 3;
         
         async function checkGameStatus() {
             try {
@@ -116,6 +118,11 @@
                 const data = await res.json();
                 
                 if (data.state === 'ENDED' || data.state === 'CLOSED') {
+                    consecutiveEndStateChecks += 1;
+                    if (consecutiveEndStateChecks < END_STATE_CONFIRMATION_THRESHOLD) {
+                        return;
+                    }
+
                     if (!gameEnded) {
                         gameEnded = true;
                         // Disable interactions
@@ -158,6 +165,8 @@
                     if (gameStatusInterval) {
                         clearInterval(gameStatusInterval);
                     }
+                } else {
+                    consecutiveEndStateChecks = 0;
                 }
             } catch (err) {
                 console.error('Game status check failed:', err);

--- a/tests/test_game_flow.py
+++ b/tests/test_game_flow.py
@@ -4,6 +4,7 @@ import os
 import csv
 import io
 from urllib.parse import urlparse, parse_qs
+from fnmatch import fnmatch
 
 # Test with the actual MODERATOR_PASSWORD from .env
 MODERATOR_PASSWORD = os.getenv("MODERATOR_PASSWORD", "test-password")
@@ -192,6 +193,69 @@ class TestGameFlow:
         assert data.get("status") == "in_game"
         assert data.get("role") == "player1"
         assert data.get("game_id") == game_id
+
+    def test_game_status_survives_temporary_redis_read_failure(self, client, reset_globals, monkeypatch):
+        """Player status should stay available if Redis has a transient read failure."""
+        import app as app_module
+
+        class FakeRedis:
+            def __init__(self):
+                self.values = {}
+                self.hashes = {}
+                self.fail_reads = False
+
+            def get(self, key):
+                if self.fail_reads:
+                    raise RuntimeError("temporary redis read failure")
+                return self.values.get(key)
+
+            def set(self, key, value):
+                self.values[key] = value
+
+            def delete(self, key):
+                self.values.pop(key, None)
+                self.hashes.pop(key, None)
+
+            def hgetall(self, key):
+                if self.fail_reads:
+                    raise RuntimeError("temporary redis read failure")
+                return dict(self.hashes.get(key, {}))
+
+            def hset(self, key, mapping=None, **kwargs):
+                bucket = self.hashes.setdefault(key, {})
+                if mapping:
+                    bucket.update(mapping)
+                bucket.update(kwargs)
+
+            def keys(self, pattern):
+                all_keys = list(self.values.keys()) + list(self.hashes.keys())
+                return [key for key in all_keys if fnmatch(key, pattern)]
+
+        fake_redis = FakeRedis()
+        monkeypatch.setattr(app_module, "redis_client", fake_redis)
+
+        self.moderator_login(client)
+        res_open = client.post("/moderator/control/open", json={})
+        game_id = json.loads(res_open.data).get("game_id")
+
+        tokens_res = client.post("/moderator/tokens/generate", json={"count": 2})
+        tokens = self.extract_tokens_from_csv(tokens_res.data)
+
+        res1 = client.post("/join/enter", json={"token": tokens[0]})
+        p1_id = json.loads(res1.data)["participant_id"]
+
+        client.post("/join/enter", json={"token": tokens[1]})
+        client.post("/moderator/control/start", json={})
+
+        fake_redis.fail_reads = True
+
+        res = client.get(f"/game/status?game_id={game_id}&participant_id={p1_id}")
+        assert res.status_code == 200
+
+        data = json.loads(res.data)
+        assert data.get("game_id") == game_id
+        assert data.get("state") == "IN_PROGRESS"
+        assert data.get("is_player") is True
 
     def test_moderator_close_entry(self, client, reset_globals):
         """Test moderator closing entry manually before 2 players join."""


### PR DESCRIPTION
This PR:

- Hardened backend runtime-state reads:
  - Added resilient fallback behavior for game/session state lookups.
  - Kept per-game status checks focused on requested `game_id` in `/game/status`.
- Added frontend tolerance against transient status glitches:
  - Player 1, Player 2, and Moderator now require **3 consecutive** `ENDED/CLOSED` poll results before disabling interactions.
  - End-state counter resets when normal state is observed.

Fixes #70 