### PR TITLE
feat: make Redis auth optional for passwordless deployments

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,7 +57,8 @@ MYSQL_CONFIG = {
 REDIS_CONFIG = {
     'host': os.getenv('REDIS_HOST', 'localhost'),
     'port': int(os.getenv('REDIS_PORT', 6379)),
-    'password': os.getenv('REDIS_PASSWORD'),
+    # Empty string should behave like "no password" to avoid AUTH errors.
+    'password': os.getenv('REDIS_PASSWORD') or None,
     'db': int(os.getenv('REDIS_DB', 0)),
     'decode_responses': True,  # Return strings instead of bytes
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,18 @@ services:
       - sh
       - -c
       - |
-        if [ -z "$REDIS_PASSWORD" ]; then
-          echo "REDIS_PASSWORD is required" >&2
-          exit 1
+        if [ -n "$REDIS_PASSWORD" ]; then
+          exec redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
         fi
-        exec redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
+        exec redis-server --appendonly yes
     volumes:
       - redis-data:/data
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test:
+        - CMD-SHELL
+        - if [ -n "$REDIS_PASSWORD" ]; then redis-cli -a "$REDIS_PASSWORD" ping; else redis-cli ping; fi
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
This PR makes Redis authentication optional so the app can run in environments with or without a Redis password.

It updates startup/config behavior to:
- Use --requirepass only when REDIS_PASSWORD is set.
- Handle empty/missing REDIS_PASSWORD safely in app config.
