### PR TITLE
Migrate Gunicorn runtime from eventlet to gevent and update run docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data/game_log.json
 nohup.out
 db/games.db
 site/
+README-dev.md

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ app.config.update(
     SECRET_KEY=SECRET_KEY,
     TEMPLATES_AUTO_RELOAD=True,
 )
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="gevent")
 
 MYSQL_CONFIG = {
     'host': os.getenv('MYSQL_HOST', 'localhost'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click==8.3.0
 cryptography==42.0.8
 Flask==3.1.2
 flask-socketio==5.5.1
-eventlet==0.40.3
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
@@ -16,3 +15,5 @@ redis==5.0.1
 gunicorn==25.3.0
 mkdocs==1.6.1
 mkdocs-material==9.5.39
+gevent==24.11.1
+gevent-websocket==0.10.1

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,7 +1,6 @@
 # wsgi.py
-import eventlet
-
-eventlet.monkey_patch()
+from gevent import monkey
+monkey.patch_all()
 
 from app import app, socketio
 


### PR DESCRIPTION
- switch deployment guidance to gevent websocket worker 
- update wsgi bootstrap for gevent monkey patching
- keep local run steps aligned with new worker setup