### PR TITLE
chore(env): migrate app config to DB_* variables

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -155,11 +155,11 @@ pip install -r requirements.txt
 # Create .env file with required variables
 echo "SECRET_KEY=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" > .env
 echo "MODERATOR_PASSWORD=your-secure-password" >> .env
-echo "MYSQL_HOST=localhost" >> .env
-echo "MYSQL_PORT=3306" >> .env
-echo "MYSQL_USER=your_user" >> .env
-echo "MYSQL_PASSWORD=your_password" >> .env
-echo "MYSQL_DATABASE=your_database" >> .env
+echo "DB_HOST=localhost" >> .env
+echo "DB_PORT=3306" >> .env
+echo "DB_USER=your_user" >> .env
+echo "DB_PWD=your_password" >> .env
+echo "DB_NAME=your_database" >> .env
 echo "REDIS_HOST=localhost" >> .env
 echo "REDIS_PORT=6379" >> .env
 echo "REDIS_DB=0" >> .env

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      DB_ROOT_USER: root
+      DB_ROOT_PASSWORD: root
+      DB_HOST: localhost
+      DB_PORT: "3306"
+      DB_USER: xposed_user
+      DB_PWD: xposed_pass
+      DB_NAME: xposed_db
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
@@ -17,10 +25,11 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_USER: xposed_user
-          MYSQL_PASSWORD: xposed_pass
-          MYSQL_DATABASE: xposed_db
+          # MySQL image expects MYSQL_* names for container initialization.
+          MYSQL_ROOT_PASSWORD: ${{ env.DB_ROOT_PASSWORD }}
+          MYSQL_USER: ${{ env.DB_USER }}
+          MYSQL_PASSWORD: ${{ env.DB_PWD }}
+          MYSQL_DATABASE: ${{ env.DB_NAME }}
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
@@ -48,13 +57,13 @@ jobs:
         run: |
           echo "SECRET_KEY=test-secret-key-for-ci" > .env
           echo "MODERATOR_PASSWORD=test-password" >> .env
-          echo "MYSQL_ROOT_USER=root" >> .env
-          echo "MYSQL_ROOT_PASSWORD=root" >> .env
-          echo "MYSQL_HOST=localhost" >> .env
-          echo "MYSQL_PORT=3306" >> .env
-          echo "MYSQL_USER=xposed_user" >> .env
-          echo "MYSQL_PASSWORD=xposed_pass" >> .env
-          echo "MYSQL_DATABASE=xposed_db" >> .env
+          echo "DB_ROOT_USER=${DB_ROOT_USER}" >> .env
+          echo "DB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}" >> .env
+          echo "DB_HOST=${DB_HOST}" >> .env
+          echo "DB_PORT=${DB_PORT}" >> .env
+          echo "DB_USER=${DB_USER}" >> .env
+          echo "DB_PWD=${DB_PWD}" >> .env
+          echo "DB_NAME=${DB_NAME}" >> .env
 
       - name: Run tests with pytest
         run: pytest tests/ -v --tb=short

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import pymysql
 import time
 import uuid
 from contextlib import contextmanager
+from urllib.parse import unquote, urlparse
 from dotenv import load_dotenv
 from flask import (
     Flask,
@@ -30,6 +31,62 @@ load_dotenv()
 # ---------------------------------------------------------------------
 app = Flask(__name__)
 
+
+def env_first(*keys, default=None):
+    """Return the first non-empty environment variable among keys."""
+    for key in keys:
+        value = os.getenv(key)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def _int_or_default(value, default):
+    """Safely parse int-like env values with fallback."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _db_config_from_env():
+    """Build DB config from DATABASE_URL and DB_* env keys."""
+    config = {
+        'host': env_first('DB_HOST', default='localhost'),
+        'port': _int_or_default(env_first('DB_PORT', default='3306'), 3306),
+        'user': env_first('DB_USER'),
+        'password': env_first('DB_PWD'),
+        'database': env_first('DB_NAME'),
+        'charset': 'utf8mb4',
+        'cursorclass': pymysql.cursors.DictCursor
+    }
+
+    database_url = os.getenv('DATABASE_URL')
+    if not database_url:
+        return config
+
+    try:
+        parsed = urlparse(database_url)
+    except Exception:
+        return config
+
+    if parsed.scheme not in ('mysql', 'mysql+pymysql'):
+        return config
+
+    # DATABASE_URL takes precedence when provided.
+    if parsed.hostname:
+        config['host'] = parsed.hostname
+    if parsed.port:
+        config['port'] = parsed.port
+    if parsed.username:
+        config['user'] = unquote(parsed.username)
+    if parsed.password:
+        config['password'] = unquote(parsed.password)
+    if parsed.path and parsed.path != '/':
+        config['database'] = parsed.path.lstrip('/')
+
+    return config
+
 # Validate required environment variables
 SECRET_KEY = os.getenv("SECRET_KEY")
 if not SECRET_KEY:
@@ -40,19 +97,12 @@ if not SECRET_KEY:
 
 app.config.update(
     SECRET_KEY=SECRET_KEY,
+    APP_NAME=env_first("APP_NAME", default="guesswho-stereotype"),
     TEMPLATES_AUTO_RELOAD=True,
 )
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode="gevent")
 
-MYSQL_CONFIG = {
-    'host': os.getenv('MYSQL_HOST', 'localhost'),
-    'port': int(os.getenv('MYSQL_PORT', 3306)),
-    'user': os.getenv('MYSQL_USER'),
-    'password': os.getenv('MYSQL_PASSWORD'),
-    'database': os.getenv('MYSQL_DATABASE'),
-    'charset': 'utf8mb4',
-    'cursorclass': pymysql.cursors.DictCursor
-}
+DB_CONFIG = _db_config_from_env()
 
 REDIS_CONFIG = {
     'host': os.getenv('REDIS_HOST', 'localhost'),
@@ -77,10 +127,10 @@ if not IS_TESTING:
         )
 
     # Validate MySQL configuration
-    if not all([MYSQL_CONFIG['user'], MYSQL_CONFIG['password'], MYSQL_CONFIG['database']]):
+    if not all([DB_CONFIG['user'], DB_CONFIG['password'], DB_CONFIG['database']]):
         raise ValueError(
-            "MySQL configuration incomplete. "
-            "Please set MYSQL_USER, MYSQL_PASSWORD, and MYSQL_DATABASE in .env"
+            "Database configuration incomplete. "
+            "Please set DATABASE_URL or DB_USER/DB_PWD/DB_NAME in .env"
         )
 
 # Initialize Redis client
@@ -97,7 +147,7 @@ except Exception as e:
 @contextmanager
 def get_db_conn():
     """Get MySQL connection with context manager."""
-    conn = pymysql.connect(**MYSQL_CONFIG)
+    conn = pymysql.connect(**DB_CONFIG)
     try:
         yield conn
         conn.commit()
@@ -1698,8 +1748,14 @@ def moderator_generate_tokens():
     csv_writer = csv.writer(output)
     csv_writer.writerow(['join_url'])
     
-    # Use request.host_url to get the base URL
-    base_url = request.host_url.rstrip('/')
+    # Prefer APP_URL for externally shared links (e.g., reverse proxy/public domain).
+    configured_app_url = env_first("APP_URL")
+    if configured_app_url:
+        if "://" not in configured_app_url:
+            configured_app_url = f"https://{configured_app_url}"
+        base_url = configured_app_url.rstrip('/')
+    else:
+        base_url = request.host_url.rstrip('/')
     for token in tokens:
         join_url = f"{base_url}/join?token={token}"
         csv_writer.writerow([join_url])
@@ -1965,13 +2021,14 @@ if __name__ == "__main__":
     os.makedirs("db", exist_ok=True)
     
     debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("1", "true", "yes")
+    app_port = _int_or_default(env_first("APP_PORT", default="5000"), 5000)
     
     print(f"Flask-SocketIO in {'DEBUG' if debug_mode else 'PRODUCTION'} mode")
     
     socketio.run(
         app,
         host="0.0.0.0",
-        port=5000,
+        port=app_port,
         debug=debug_mode,
         use_reloader=debug_mode
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,12 @@ os.environ['TESTING'] = '1'
 from dotenv import load_dotenv
 load_dotenv()
 
-# Set CI defaults for MySQL if not already set by .env
-os.environ.setdefault('MYSQL_HOST', 'localhost')
-os.environ.setdefault('MYSQL_PORT', '3306')
-os.environ.setdefault('MYSQL_USER', 'xposed_user')
-os.environ.setdefault('MYSQL_PASSWORD', 'xposed_pass')
-os.environ.setdefault('MYSQL_DATABASE', 'xposed_db')
+# Set CI defaults for DB config if not already set by .env
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_PORT', '3306')
+os.environ.setdefault('DB_USER', 'xposed_user')
+os.environ.setdefault('DB_PWD', 'xposed_pass')
+os.environ.setdefault('DB_NAME', 'xposed_db')
 os.environ.setdefault('SECRET_KEY', 'test-secret-key')
 os.environ.setdefault('MODERATOR_PASSWORD', 'test-password')
 
@@ -32,21 +32,21 @@ def ensure_test_password():
 def test_db():
     """Setup test database - shared by all fixtures."""
     import app as app_module
-    original_mysql_config = dict(app_module.MYSQL_CONFIG)
+    original_db_config = dict(app_module.DB_CONFIG)
     test_database = 'xposed_db_test'
     
     # Use test database name
-    app_module.MYSQL_CONFIG['database'] = test_database
+    app_module.DB_CONFIG['database'] = test_database
     
-    admin_user = os.getenv('MYSQL_ROOT_USER', 'root')
-    admin_password = os.getenv('MYSQL_ROOT_PASSWORD')
+    admin_user = os.getenv('DB_ROOT_USER', 'root')
+    admin_password = os.getenv('DB_ROOT_PASSWORD')
     admin_conn_user = None
 
     # Create test database using admin credentials (required for CREATE/DROP)
     try:
         admin_conn = pymysql.connect(
-            host=original_mysql_config['host'],
-            port=original_mysql_config['port'],
+            host=original_db_config['host'],
+            port=original_db_config['port'],
             user=admin_user,
             password=admin_password,
             charset='utf8mb4'
@@ -59,16 +59,16 @@ def test_db():
     if admin_conn is None:
         try:
             admin_conn = pymysql.connect(
-                host=original_mysql_config['host'],
-                port=original_mysql_config['port'],
-                user=original_mysql_config['user'],
-                password=original_mysql_config['password'],
+                host=original_db_config['host'],
+                port=original_db_config['port'],
+                user=original_db_config['user'],
+                password=original_db_config['password'],
                 charset='utf8mb4'
             )
-            admin_conn_user = original_mysql_config['user']
+            admin_conn_user = original_db_config['user']
         except pymysql.err.OperationalError as exc:
             raise RuntimeError(
-                "Test DB setup failed. Set MYSQL_ROOT_PASSWORD (and optional MYSQL_ROOT_USER) "
+                "Test DB setup failed. Set DB_ROOT_PASSWORD (and optional DB_ROOT_USER) "
                 "so tests can create/drop the test database."
             ) from exc
 
@@ -76,11 +76,11 @@ def test_db():
     cursor.execute(f"DROP DATABASE IF EXISTS {test_database}")
     cursor.execute(f"CREATE DATABASE {test_database} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
 
-    if admin_conn_user != original_mysql_config['user']:
+    if admin_conn_user != original_db_config['user']:
         # Grant permissions to app user on test database
         cursor.execute(
             f"GRANT ALL PRIVILEGES ON {test_database}.* TO %s@'%%'",
-            (original_mysql_config['user'],)
+            (original_db_config['user'],)
         )
         cursor.execute("FLUSH PRIVILEGES")
 
@@ -95,22 +95,22 @@ def test_db():
     yield
     
     # Cleanup: drop test database using admin credentials, fallback to app user
-    admin_user = os.getenv('MYSQL_ROOT_USER', 'root')
-    admin_password = os.getenv('MYSQL_ROOT_PASSWORD')
+    admin_user = os.getenv('DB_ROOT_USER', 'root')
+    admin_password = os.getenv('DB_ROOT_PASSWORD')
     try:
         admin_conn = pymysql.connect(
-            host=original_mysql_config['host'],
-            port=original_mysql_config['port'],
+            host=original_db_config['host'],
+            port=original_db_config['port'],
             user=admin_user,
             password=admin_password,
             charset='utf8mb4'
         )
     except pymysql.err.OperationalError:
         admin_conn = pymysql.connect(
-            host=original_mysql_config['host'],
-            port=original_mysql_config['port'],
-            user=original_mysql_config['user'],
-            password=original_mysql_config['password'],
+            host=original_db_config['host'],
+            port=original_db_config['port'],
+            user=original_db_config['user'],
+            password=original_db_config['password'],
             charset='utf8mb4'
         )
 
@@ -120,7 +120,7 @@ def test_db():
     cursor.close()
     admin_conn.close()
     
-    app_module.MYSQL_CONFIG.update(original_mysql_config)
+    app_module.DB_CONFIG.update(original_db_config)
 
 @pytest.fixture
 def client(test_db):

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,8 +1,14 @@
 # wsgi.py
+import os
+
 from gevent import monkey
 monkey.patch_all()
 
 from app import app, socketio
 
 if __name__ == "__main__":
-    socketio.run(app, host="0.0.0.0", port=5000, debug=False)
+    try:
+        port = int(os.getenv("APP_PORT", "5000"))
+    except ValueError:
+        port = 5000
+    socketio.run(app, host="0.0.0.0", port=port, debug=False)


### PR DESCRIPTION
## Summary
This PR migrates application configuration from MYSQL_* environment variables to DB_* variables and aligns runtime behavior for local and VM deployment.

## What changed
- Switched database configuration handling to DB_HOST, DB_PORT, DB_USER, DB_PWD, DB_NAME.
- Kept support for DATABASE_URL as an optional override.
- Updated config naming in code from MYSQL_CONFIG to DB_CONFIG.
- Updated startup validation messages to reference DB_* variables.
- Updated test configuration defaults from MYSQL_* to DB_*.
- Added APP_PORT-based binding support in WSGI startup.
- Added APP_URL usage for generated token/join links.

## Why
- Standardize environment variable naming across local and production.
- Reduce confusion between legacy and current DB config.
- Make deployment behavior clearer and easier to manage on VM.
