### PR TITLE
add moderator recording controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -235,9 +235,15 @@ def get_game_state(game_id):
             except (TypeError, ValueError):
                 data['round_number'] = 1
         # Convert "null" sentinels back to None
-        for key in ['player1_id', 'player2_id']:
+        for key in ['player1_id', 'player2_id', 'recording_id']:
             if key in data and data[key] == "null":
                 data[key] = None
+        if 'recording_active' in data:
+            value = data['recording_active']
+            if isinstance(value, str):
+                data['recording_active'] = value.lower() in ('true', '1', 'yes')
+            else:
+                data['recording_active'] = bool(value)
         return data
     except Exception as e:
         print(f"Error getting game state: {e}")
@@ -378,6 +384,17 @@ def remove_voice_participant(game_id, client_id):
         get_redis().hdel(f"voice:{game_id}", client_id)
     except Exception as e:
         print(f"Error removing voice participant: {e}")
+
+
+def clear_voice_participants(game_id):
+    """Remove all voice participants for a game."""
+    VOICE_PARTICIPANTS.pop(game_id, None)
+    if not get_redis():
+        return
+    try:
+        get_redis().delete(f"voice:{game_id}")
+    except Exception as e:
+        print(f"Error clearing voice participants: {e}")
 
 # CURRENT_SESSION_GAME_ID helper
 def get_current_session_game_id():
@@ -1389,6 +1406,47 @@ def join_enter():
     })
 
 
+def _utc_iso_timestamp():
+    """Return current UTC time as ISO-8601 string with Z suffix."""
+    return datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
+
+
+def _resolve_moderator_game_context():
+    """Return (game_id, game_state) for the moderator's active session."""
+    moderator_game_id = session.get("moderator_session_game_id")
+    if not moderator_game_id:
+        moderator_game_id = get_current_session_game_id()
+        if moderator_game_id:
+            session["moderator_session_game_id"] = moderator_game_id
+    if not moderator_game_id:
+        return None, None
+    game_state = get_game_state(moderator_game_id)
+    if not game_state:
+        return None, None
+    return moderator_game_id, game_state
+
+
+def _stop_active_recording(game_id, game_state, reason="moderator_stop"):
+    """Stop an active recording and broadcast recording_stop. Returns payload or None."""
+    if not game_state.get("recording_active"):
+        return None
+
+    recording_id = game_state.get("recording_id")
+    server_ts = _utc_iso_timestamp()
+    game_state["recording_active"] = False
+    set_game_state(game_id, game_state)
+
+    payload = {
+        "game_id": game_id,
+        "recording_id": recording_id,
+        "server_ts": server_ts,
+    }
+    socketio.emit("recording_stop", payload, to=f"game:{game_id}")
+    record_event("system", "recording_stop", game_id, text=reason)
+    print(f"⏹️ Recording stopped for game {game_id} ({recording_id})")
+    return payload
+
+
 @app.route("/moderator/control")
 def moderator_control():
     """Moderator control panel."""
@@ -1439,7 +1497,9 @@ def moderator_control_status():
         "can_swap_roles": game_state.get('state') == 'IN_PROGRESS' and round_number == 1,
         "waiting_count": len(game_state.get('waiting_participants', [])),
         "player1_id": game_state.get('player1_id'),
-        "player2_id": game_state.get('player2_id')
+        "player2_id": game_state.get('player2_id'),
+        "recording_active": bool(game_state.get("recording_active")),
+        "recording_id": game_state.get("recording_id") if game_state.get("recording_active") else None,
     })
 
 
@@ -1484,7 +1544,9 @@ def moderator_open_entry():
             'player1_id': None,
             'player2_id': None,
             'round_number': 1,
-            'round_phase': 'ACTIVE'
+            'round_phase': 'ACTIVE',
+            'recording_active': False,
+            'recording_id': None,
         })
         
         # Update the global for participant joins
@@ -1586,10 +1648,18 @@ def moderator_end_game():
     if game_state.get('state') == 'CLOSED':
         return jsonify({"status": "error", "message": "No active session"}), 400
 
+    _stop_active_recording(moderator_game_id, game_state, reason="game_ended")
+
     close_round(moderator_game_id)
     game_state['state'] = 'ENDED'
     set_game_state(moderator_game_id, game_state)
-    
+    clear_voice_participants(moderator_game_id)
+
+    socketio.emit(
+        "game_ended",
+        {"game_id": moderator_game_id, "state": "ENDED"},
+        to=f"game:{moderator_game_id}",
+    )
     record_event("system", "game_ended", moderator_game_id)
     print(f"🏁 Ended game {moderator_game_id}")
     
@@ -1717,6 +1787,81 @@ def moderator_reset_session():
     print(f"🔄 Reset session {moderator_game_id}")
     
     return jsonify({"status": "ok"})
+
+
+@app.route("/moderator/control/recording/start", methods=["POST"])
+def moderator_recording_start():
+    """Start a moderator-controlled recording session for the active game."""
+    if not session.get("moderator"):
+        return jsonify({"status": "error", "message": "Unauthorized"}), 403
+
+    moderator_game_id, game_state = _resolve_moderator_game_context()
+    if not moderator_game_id or not game_state:
+        return jsonify({"status": "error", "message": "No active session"}), 400
+
+    if game_state.get("state") != "IN_PROGRESS":
+        return jsonify({
+            "status": "error",
+            "message": f"Cannot start recording in state: {game_state.get('state')}",
+        }), 400
+
+    if game_state.get("recording_active"):
+        return jsonify({"status": "error", "message": "Recording already active"}), 400
+
+    recording_id = uuid.uuid4().hex
+    server_ts = _utc_iso_timestamp()
+    game_state["recording_active"] = True
+    game_state["recording_id"] = recording_id
+    set_game_state(moderator_game_id, game_state)
+
+    payload = {
+        "game_id": moderator_game_id,
+        "recording_id": recording_id,
+        "server_ts": server_ts,
+    }
+    socketio.emit("recording_start", payload, to=f"game:{moderator_game_id}")
+    record_event(
+        "system",
+        "recording_start",
+        moderator_game_id,
+        text=f"recording_id={recording_id}",
+    )
+    print(f"⏺️ Recording started for game {moderator_game_id} ({recording_id})")
+
+    return jsonify({
+        "status": "ok",
+        "game_id": moderator_game_id,
+        "recording_id": recording_id,
+        "server_ts": server_ts,
+    })
+
+
+@app.route("/moderator/control/recording/stop", methods=["POST"])
+def moderator_recording_stop():
+    """Stop the active recording session for the current game."""
+    if not session.get("moderator"):
+        return jsonify({"status": "error", "message": "Unauthorized"}), 403
+
+    moderator_game_id, game_state = _resolve_moderator_game_context()
+    if not moderator_game_id or not game_state:
+        return jsonify({"status": "error", "message": "No active session"}), 400
+
+    if game_state.get("state") != "IN_PROGRESS":
+        return jsonify({
+            "status": "error",
+            "message": f"Cannot stop recording in state: {game_state.get('state')}",
+        }), 400
+
+    if not game_state.get("recording_active"):
+        return jsonify({"status": "ok", "message": "No active recording"})
+
+    payload = _stop_active_recording(moderator_game_id, game_state, reason="moderator_stop")
+    return jsonify({
+        "status": "ok",
+        "game_id": moderator_game_id,
+        "recording_id": payload.get("recording_id") if payload else None,
+        "server_ts": payload.get("server_ts") if payload else None,
+    })
 
 
 @app.route("/moderator/tokens/generate", methods=["POST"])

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,6 +88,16 @@ This page summarizes HTTP routes and Socket.IO events exposed by the application
 - POST /moderator/control/reset
   - Resets current session to CLOSED.
 
+- POST /moderator/control/recording/start
+  - Starts a recording session while game state is IN_PROGRESS.
+  - Broadcasts recording_start to room game:{game_id}.
+  - Response includes recording_id and server_ts (UTC ISO-8601).
+
+- POST /moderator/control/recording/stop
+  - Stops the active recording session.
+  - Broadcasts recording_stop to room game:{game_id}.
+  - Idempotent when no recording is active (returns ok).
+
 - POST /moderator/tokens/generate
   - Body: {"count": 1..100}
   - Returns CSV file with tokenized join links.
@@ -129,6 +139,13 @@ This page summarizes HTTP routes and Socket.IO events exposed by the application
 - eliminate
 - round_complete
 - roles_swapped
+- recording_start
+  - Payload: {"game_id", "recording_id", "server_ts"}
+- recording_stop
+  - Payload: {"game_id", "recording_id", "server_ts"}
+- game_ended
+  - Payload: {"game_id", "state"}
+  - Clients should leave voice when received.
 
 ## State Model
 

--- a/static/webrtc.js
+++ b/static/webrtc.js
@@ -340,6 +340,11 @@
     // Socket event: receive WebRTC signal from peer
     socket.on("webrtc_signal", handleIncomingSignal);
 
+    socket.on("game_ended", (data) => {
+      if (!data || data.game_id !== gameId) return;
+      stopVoice();
+    });
+
     setStatus("idle");
     setButton(false);
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -86,6 +86,42 @@
         .btn-reset:hover:not(:disabled) {
             background: #757575;
         }
+        .btn-record-start {
+            background: #c62828;
+            color: white;
+        }
+        .btn-record-start:hover:not(:disabled) {
+            background: #b71c1c;
+        }
+        .btn-record-stop {
+            background: #6a1b9a;
+            color: white;
+        }
+        .btn-record-stop:hover:not(:disabled) {
+            background: #4a148c;
+        }
+        .recording-badge {
+            display: inline-block;
+            margin-left: 10px;
+            padding: 4px 10px;
+            border-radius: 12px;
+            background: #ffebee;
+            color: #c62828;
+            font-size: 0.85em;
+            font-weight: bold;
+        }
+        .recording-controls {
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+            flex: 1;
+            min-width: 150px;
+        }
+        .recording-controls .control-btn {
+            flex: 1;
+            width: 100%;
+            min-height: 52px;
+        }
         .info-section {
             background: white;
             padding: 20px;
@@ -197,6 +233,10 @@
             <button id="btn-start" class="control-btn btn-start">▶️ Start Game</button>
             <button id="btn-swap" class="control-btn btn-start">🔁 Swap Roles</button>
             <button id="btn-end" class="control-btn btn-end">⏹️ End Game</button>
+            <div class="recording-controls">
+                <button id="btn-record-start" class="control-btn btn-record-start">⏺️ Start Recording</button>
+                <button id="btn-record-stop" class="control-btn btn-record-stop">⏹️ Stop Recording</button>
+            </div>
         </div>
 
         <div class="info-section">
@@ -284,7 +324,11 @@
                     } else if (data.state === 'READY') {
                         statusHtml += `<p>⏳ 2 participants ready - Click "Start Game" to begin</p>`;
                     } else if (data.state === 'IN_PROGRESS') {
-                        statusHtml += `<p>🎮 Game in progress (Round ${data.round_number || 1})</p>`;
+                        statusHtml += `<p>🎮 Game in progress (Round ${data.round_number || 1})`;
+                        if (data.recording_active) {
+                            statusHtml += `<span class="recording-badge">⏺ REC</span>`;
+                        }
+                        statusHtml += `</p>`;
                     } else if (data.state === 'ENDED') {
                         statusHtml += `<p>🏁 Game ended - Click "Open Entry" to start a new session</p>`;
                     }
@@ -337,11 +381,15 @@
             const btnStart = document.getElementById('btn-start');
             const btnSwap = document.getElementById('btn-swap');
             const btnEnd = document.getElementById('btn-end');
+            const btnRecordStart = document.getElementById('btn-record-start');
+            const btnRecordStop = document.getElementById('btn-record-stop');
 
             btnOpen.disabled = true;
             btnStart.disabled = true;
             btnSwap.disabled = true;
             btnEnd.disabled = true;
+            btnRecordStart.disabled = true;
+            btnRecordStop.disabled = true;
 
             if (state === 'NO_SESSION' || state === 'CLOSED' || state === 'ENDED') {
                 btnOpen.disabled = false;
@@ -354,6 +402,13 @@
             }
             if (state === 'OPEN' || state === 'READY' || state === 'IN_PROGRESS') {
                 btnEnd.disabled = false;
+            }
+            if (state === 'IN_PROGRESS') {
+                if (statusData?.recording_active) {
+                    btnRecordStop.disabled = false;
+                } else {
+                    btnRecordStart.disabled = false;
+                }
             }
         }
 
@@ -395,6 +450,34 @@
                     alert('✅ Roles swapped. Round 2 started.');
                 } else {
                     alert('Failed to swap roles: ' + (data.message || 'Unknown error'));
+                }
+            } catch (err) {
+                alert('Error: ' + err.message);
+            }
+        };
+
+        document.getElementById('btn-record-start').onclick = async () => {
+            try {
+                const res = await fetch('/moderator/control/recording/start', { method: 'POST' });
+                const data = await res.json();
+                if (data.status === 'ok') {
+                    updateStatus();
+                } else {
+                    alert('Failed to start recording: ' + (data.message || 'Unknown error'));
+                }
+            } catch (err) {
+                alert('Error: ' + err.message);
+            }
+        };
+
+        document.getElementById('btn-record-stop').onclick = async () => {
+            try {
+                const res = await fetch('/moderator/control/recording/stop', { method: 'POST' });
+                const data = await res.json();
+                if (data.status === 'ok') {
+                    updateStatus();
+                } else {
+                    alert('Failed to stop recording: ' + (data.message || 'Unknown error'));
                 }
             } catch (err) {
                 alert('Error: ' + err.message);

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -85,6 +85,7 @@
         const seenJoins = new Set();
         
         // Track game end state
+        let voice = null;
         let gameEnded = false;
         let consecutiveEndStateChecks = 0;
         const END_STATE_CONFIRMATION_THRESHOLD = 3;
@@ -129,6 +130,7 @@
 
                     if (!gameEnded) {
                         gameEnded = true;
+                        if (voice) voice.stopVoice();
                         // Disable interactions
                         document.getElementById('chat-input').disabled = true;
                         document.getElementById('send-chat').disabled = true;
@@ -255,7 +257,7 @@
         });
 
         // --- Voice (WebRTC) -------------------------------------------
-        const voice = setupVoice({
+        voice = setupVoice({
             socket,
             gameId,
             role: "moderator",
@@ -266,6 +268,13 @@
         if (MicCheck.isMicReady()) {
             voice.startVoice();
         }
+
+        socket.on('recording_start', (data) => {
+            console.log('[Recording] started', data);
+        });
+        socket.on('recording_stop', (data) => {
+            console.log('[Recording] stopped', data);
+        });
     </script>
 </body>
 

--- a/templates/player1.html
+++ b/templates/player1.html
@@ -90,6 +90,7 @@
             .catch(err => console.error('Failed to load transcript:', err));
 
         // --- Game Status Polling -----------------------------------------------
+        let voice = null;
         let gameEnded = false;
         let consecutiveEndStateChecks = 0;
         const END_STATE_CONFIRMATION_THRESHOLD = 3;
@@ -112,6 +113,7 @@
 
                     if (!gameEnded) {
                         gameEnded = true;
+                        if (voice) voice.stopVoice();
                         // Disable interactions
                         document.getElementById('chat-input').disabled = true;
                         document.getElementById('send-btn').disabled = true;
@@ -227,7 +229,7 @@
         // Player 1 does not receive elimination messages - only moderator and player2 should see them
 
         // --- Voice (WebRTC) -------------------------------------------
-        const voice = setupVoice({
+        voice = setupVoice({
             socket,
             gameId,
             role: 'player1',
@@ -238,6 +240,13 @@
         if (MicCheck.isMicReady()) {
             voice.startVoice();
         }
+
+        socket.on('recording_start', (data) => {
+            console.log('[Recording] started', data);
+        });
+        socket.on('recording_stop', (data) => {
+            console.log('[Recording] stopped', data);
+        });
     </script>
 </body>
 

--- a/templates/player2.html
+++ b/templates/player2.html
@@ -117,6 +117,7 @@
             .catch(err => console.error('Failed to load transcript:', err));
 
         // --- Game Status Polling -----------------------------------------------
+        let voice = null;
         let gameEnded = false;
         let consecutiveEndStateChecks = 0;
         const END_STATE_CONFIRMATION_THRESHOLD = 3;
@@ -139,6 +140,7 @@
 
                     if (!gameEnded) {
                         gameEnded = true;
+                        if (voice) voice.stopVoice();
                         // Disable interactions
                         document.getElementById('chat-input').disabled = true;
                         document.getElementById('send-btn').disabled = true;
@@ -287,7 +289,7 @@
         });
 
         // --- Voice (WebRTC) -------------------------------------------
-        const voice = setupVoice({
+        voice = setupVoice({
             socket,
             gameId,
             role: 'player2',
@@ -298,6 +300,13 @@
         if (MicCheck.isMicReady()) {
             voice.startVoice();
         }
+
+        socket.on('recording_start', (data) => {
+            console.log('[Recording] started', data);
+        });
+        socket.on('recording_stop', (data) => {
+            console.log('[Recording] stopped', data);
+        });
     </script>
 </body>
 

--- a/tests/test_recording_control.py
+++ b/tests/test_recording_control.py
@@ -1,0 +1,174 @@
+import csv
+import io
+import json
+from urllib.parse import parse_qs, urlparse
+
+
+class TestRecordingControl:
+    """Test moderator recording start/stop controls and socket broadcasts."""
+
+    def moderator_login(self, client):
+        with client.session_transaction() as sess:
+            sess["moderator"] = True
+        return client
+
+    @staticmethod
+    def extract_tokens_from_csv(csv_response_data):
+        csv_content = csv_response_data.decode("utf-8")
+        csv_reader = csv.reader(io.StringIO(csv_content))
+        rows = list(csv_reader)
+        tokens = []
+        for row in rows[1:]:
+            url = row[0]
+            parsed = urlparse(url)
+            query_params = parse_qs(parsed.query)
+            token = query_params.get("token", [None])[0]
+            if token:
+                tokens.append(token)
+        return tokens
+
+    def _start_game_in_progress(self, client):
+        from app import get_game_state
+
+        self.moderator_login(client)
+        res_open = client.post("/moderator/control/open", json={})
+        game_id = json.loads(res_open.data).get("game_id")
+
+        tokens_res = client.post("/moderator/tokens/generate", json={"count": 2})
+        tokens = self.extract_tokens_from_csv(tokens_res.data)
+        client.post("/join/enter", json={"token": tokens[0]})
+        client.post("/join/enter", json={"token": tokens[1]})
+        client.post("/moderator/control/start", json={})
+
+        game_state = get_game_state(game_id)
+        assert game_state["state"] == "IN_PROGRESS"
+        return game_id
+
+    def test_recording_start_requires_auth(self, client, reset_globals):
+        res = client.post("/moderator/control/recording/start", json={})
+        assert res.status_code == 403
+
+    def test_recording_stop_requires_auth(self, client, reset_globals):
+        res = client.post("/moderator/control/recording/stop", json={})
+        assert res.status_code == 403
+
+    def test_recording_start_requires_in_progress(self, client, reset_globals):
+        self.moderator_login(client)
+        client.post("/moderator/control/open", json={})
+
+        res = client.post("/moderator/control/recording/start", json={})
+        assert res.status_code == 400
+        data = json.loads(res.data)
+        assert data["status"] == "error"
+
+    def test_recording_start_and_stop_updates_state(self, client, reset_globals):
+        from app import get_game_state
+
+        game_id = self._start_game_in_progress(client)
+
+        res_start = client.post("/moderator/control/recording/start", json={})
+        assert res_start.status_code == 200
+        start_data = json.loads(res_start.data)
+        assert start_data["status"] == "ok"
+        assert start_data["recording_id"]
+        assert start_data["server_ts"].endswith("Z")
+
+        game_state = get_game_state(game_id)
+        assert game_state["recording_active"] is True
+        assert game_state["recording_id"] == start_data["recording_id"]
+
+        res_stop = client.post("/moderator/control/recording/stop", json={})
+        assert res_stop.status_code == 200
+        stop_data = json.loads(res_stop.data)
+        assert stop_data["status"] == "ok"
+        assert stop_data["recording_id"] == start_data["recording_id"]
+
+        game_state = get_game_state(game_id)
+        assert game_state["recording_active"] is False
+
+    def test_recording_start_rejects_duplicate(self, client, reset_globals):
+        self._start_game_in_progress(client)
+        client.post("/moderator/control/recording/start", json={})
+
+        res = client.post("/moderator/control/recording/start", json={})
+        assert res.status_code == 400
+        data = json.loads(res.data)
+        assert "already active" in data["message"].lower()
+
+    def test_recording_stop_is_idempotent(self, client, reset_globals):
+        self._start_game_in_progress(client)
+
+        res = client.post("/moderator/control/recording/stop", json={})
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert data["status"] == "ok"
+        assert data.get("message") == "No active recording"
+
+    def test_recording_status_in_control_status(self, client, reset_globals):
+        self._start_game_in_progress(client)
+        client.post("/moderator/control/recording/start", json={})
+
+        res = client.get("/moderator/control/status")
+        data = json.loads(res.data)
+        assert data["status"] == "ok"
+        assert data["recording_active"] is True
+        assert data["recording_id"]
+
+    def test_recording_start_emits_socket_event(
+        self, client, socketio_client, reset_globals
+    ):
+        game_id = self._start_game_in_progress(client)
+
+        socketio_client.emit(
+            "join",
+            {"game_id": game_id, "role": "player1", "participant_id": "test-participant"},
+        )
+        socketio_client.get_received()
+
+        res = client.post("/moderator/control/recording/start", json={})
+        assert res.status_code == 200
+        start_data = json.loads(res.data)
+
+        received = socketio_client.get_received()
+        recording_events = [
+            item
+            for item in received
+            if item.get("name") == "recording_start"
+        ]
+        assert len(recording_events) == 1
+        payload = recording_events[0]["args"][0]
+        assert payload["game_id"] == game_id
+        assert payload["recording_id"] == start_data["recording_id"]
+        assert payload["server_ts"].endswith("Z")
+
+    def test_end_game_emits_game_ended_socket(
+        self, client, socketio_client, reset_globals
+    ):
+        game_id = self._start_game_in_progress(client)
+
+        socketio_client.emit(
+            "join",
+            {"game_id": game_id, "role": "player1", "participant_id": "test-participant"},
+        )
+        socketio_client.get_received()
+
+        client.post("/moderator/control/end", json={})
+
+        received = socketio_client.get_received()
+        ended_events = [item for item in received if item.get("name") == "game_ended"]
+        assert len(ended_events) == 1
+        payload = ended_events[0]["args"][0]
+        assert payload["game_id"] == game_id
+        assert payload["state"] == "ENDED"
+
+    def test_end_game_stops_active_recording(self, client, reset_globals):
+        from app import get_game_state
+
+        game_id = self._start_game_in_progress(client)
+        client.post("/moderator/control/recording/start", json={})
+
+        client.post("/moderator/control/end", json={})
+
+        game_state = get_game_state(game_id)
+        assert game_state["state"] == "ENDED"
+        assert game_state["recording_active"] is False


### PR DESCRIPTION
Moderator recording controls

Adds Start/Stop Recording on the dashboard and broadcasts recording_start / recording_stop to all game clients (recording_id, server_ts). 

No audio capture or file storage yet.
Voice disconnects on End Game (game_ended event), recording buttons stacked on dashboard, Redis fix for recording_active.

Test: start game → start/stop recording (check console on player tabs) → end game (voice stops).
Next: feature/media-recorder + feature/audio-upload for actual audio files.