### PR TITLE
Add read-only auditor role for low-privilege staff access

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           echo "SECRET_KEY=test-secret-key-for-ci" > .env
           echo "MODERATOR_PASSWORD=test-password" >> .env
+          echo "AUDITOR_PASSWORD=test-auditor-password" >> .env
           echo "DB_ROOT_USER=${DB_ROOT_USER}" >> .env
           echo "DB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}" >> .env
           echo "DB_HOST=${DB_HOST}" >> .env

--- a/app.py
+++ b/app.py
@@ -25,6 +25,18 @@ from flask import (
 from flask_socketio import SocketIO, join_room
 import redis
 
+from auth import (
+    ROLE_AUDITOR,
+    ROLE_MODERATOR,
+    authenticate_staff,
+    can_view_game,
+    clear_staff_session,
+    get_session_role,
+    is_moderator,
+    is_staff,
+    set_staff_session,
+)
+
 load_dotenv()
 
 # ---------------------------------------------------------------------
@@ -119,6 +131,7 @@ REDIS_CONFIG = {
 }
 
 MODERATOR_PASSWORD = os.getenv("MODERATOR_PASSWORD")
+AUDITOR_PASSWORD = os.getenv("AUDITOR_PASSWORD")
 
 # Skip validation during testing
 IS_TESTING = os.getenv('TESTING') == '1'
@@ -901,16 +914,22 @@ def index():
 
 @app.route("/login", methods=["POST"])
 def login():
-    """Simple moderator login."""
-    if request.form.get("password") == MODERATOR_PASSWORD:
-        session["moderator"] = True
+    """Staff login for moderator or read-only auditor."""
+    password = request.form.get("password", "")
+    role = request.form.get("role", ROLE_MODERATOR)
+    if role not in (ROLE_MODERATOR, ROLE_AUDITOR):
+        role = ROLE_MODERATOR
+
+    if authenticate_staff(role, password, MODERATOR_PASSWORD, AUDITOR_PASSWORD):
+        set_staff_session(role)
         return redirect(url_for("dashboard"))
-    return render_template("index.html", error=True)
+    return render_template("index.html", error=True, selected_role=role)
 
 
 @app.route("/logout")
 def logout():
     """Clear session and return to login."""
+    clear_staff_session()
     session.clear()
     return redirect(url_for("index"))
 
@@ -993,12 +1012,12 @@ def check_role_binding(game_id, participant_id, required_role):
 
 @app.route("/dashboard")
 def dashboard():
-    """Moderator dashboard."""
-    if not session.get("moderator"):
+    """Staff dashboard."""
+    if not is_staff():
         return redirect(url_for("index"))
-    # Clear any previous session when moderator goes to dashboard
-    session['moderator_session_game_id'] = None
-    return render_template("dashboard.html")
+    if is_moderator():
+        session['moderator_session_game_id'] = None
+    return render_template("dashboard.html", staff_role=get_session_role())
 
 
 @app.route("/player1")
@@ -1051,22 +1070,28 @@ def player2():
 
 @app.route("/moderator")
 def moderator():
-    """Moderator live view."""
+    """Staff live observer view."""
     game_id = request.args.get("game_id")
-    if not session.get("moderator"):
+    if not is_staff():
         return redirect(url_for("index"))
     
     if not game_id:
         return "Missing game_id parameter", 400
+
+    if not can_view_game(game_id, get_current_session_game_id):
+        return "Forbidden: cannot view this session", 403
     
     chosen = get_chosen_card(game_id) or random.choice(CARDS)["id"]
     eliminated = get_eliminated_cards(game_id)
+    staff_role = get_session_role()
     return render_template(
         "moderator.html",
         game_id=game_id,
         cards=CARDS,
         eliminated=eliminated,
         secret_card={"id": chosen, "name": f"Card {chosen}"},
+        staff_role=staff_role,
+        read_only=staff_role == ROLE_AUDITOR,
     )
 
 
@@ -1450,7 +1475,7 @@ def _stop_active_recording(game_id, game_state, reason="moderator_stop"):
 @app.route("/moderator/control")
 def moderator_control():
     """Moderator control panel."""
-    if not session.get("moderator"):
+    if not is_staff():
         return redirect(url_for("index"))
     return redirect(url_for("dashboard"))
 
@@ -1458,7 +1483,7 @@ def moderator_control():
 @app.route("/moderator/control/status")
 def moderator_control_status():
     """Get current game state for moderator."""
-    if not session.get("moderator"):
+    if not is_staff():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     # Use moderator's session to track their current game, fall back to global
@@ -1506,7 +1531,7 @@ def moderator_control_status():
 @app.route("/moderator/control/open", methods=["POST"])
 def moderator_open_entry():
     """Moderator opens entry for participants."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     moderator_game_id = session.get('moderator_session_game_id')
@@ -1566,7 +1591,7 @@ def moderator_open_entry():
 @app.route("/moderator/control/close", methods=["POST"])
 def moderator_close_entry():
     """Moderator closes entry for participants."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     moderator_game_id = session.get('moderator_session_game_id')
@@ -1590,7 +1615,7 @@ def moderator_close_entry():
 @app.route("/moderator/control/start", methods=["POST"])
 def moderator_start_game():
     """Moderator starts the game (transitions READY -> IN_PROGRESS)."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     moderator_game_id = session.get('moderator_session_game_id')
@@ -1633,7 +1658,7 @@ def moderator_start_game():
 @app.route("/moderator/control/end", methods=["POST"])
 def moderator_end_game():
     """Moderator ends the game (transitions IN_PROGRESS -> ENDED)."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     moderator_game_id = session.get('moderator_session_game_id')
@@ -1669,7 +1694,7 @@ def moderator_end_game():
 @app.route("/moderator/control/swap_roles", methods=["POST"])
 def moderator_swap_roles():
     """Moderator swaps player roles for round 2 in the same game session."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
 
     moderator_game_id = session.get('moderator_session_game_id')
@@ -1761,7 +1786,7 @@ def moderator_swap_roles():
 @app.route("/moderator/control/reset", methods=["POST"])
 def moderator_reset_session():
     """Moderator resets session (transitions ENDED -> CLOSED)."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     moderator_game_id = session.get('moderator_session_game_id')
@@ -1792,7 +1817,7 @@ def moderator_reset_session():
 @app.route("/moderator/control/recording/start", methods=["POST"])
 def moderator_recording_start():
     """Start a moderator-controlled recording session for the active game."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
 
     moderator_game_id, game_state = _resolve_moderator_game_context()
@@ -1839,7 +1864,7 @@ def moderator_recording_start():
 @app.route("/moderator/control/recording/stop", methods=["POST"])
 def moderator_recording_stop():
     """Stop the active recording session for the current game."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
 
     moderator_game_id, game_state = _resolve_moderator_game_context()
@@ -1867,7 +1892,7 @@ def moderator_recording_stop():
 @app.route("/moderator/tokens/generate", methods=["POST"])
 def moderator_generate_tokens():
     """Generate access tokens for participant invitations."""
-    if not session.get("moderator"):
+    if not is_moderator():
         return jsonify({"status": "error", "message": "Unauthorized"}), 403
     
     data = request.get_json() or {}
@@ -1934,6 +1959,15 @@ def validate_role_binding(game_id, participant_id, claimed_role):
     Returns (valid: bool, error_msg: str or None)
     """
     if claimed_role == "moderator":
+        if not is_moderator():
+            return False, "Unauthorized"
+        return True, None
+
+    if claimed_role == "auditor":
+        if get_session_role() != ROLE_AUDITOR:
+            return False, "Unauthorized"
+        if not can_view_game(game_id, get_current_session_game_id):
+            return False, "Cannot observe this session"
         return True, None
 
     if not participant_id:
@@ -1953,7 +1987,7 @@ def handle_join(data):
     game_id = data.get("game_id")
     role = data.get("role", "unknown")
     participant_id = data.get("participant_id")
-    actor_participant_id = participant_id if role != "moderator" else None
+    actor_participant_id = participant_id if role not in ("moderator", "auditor") else None
     
     if not game_id:
         return {"status": "error", "message": "game_id required"}
@@ -2002,6 +2036,8 @@ def handle_chat(data):
     game_id = data.get("game_id")
     role = data.get("role", "unknown")
     participant_id = data.get("participant_id")
+    if role == ROLE_AUDITOR:
+        return {"status": "error", "message": "Read-only"}
     actor_participant_id = participant_id if role != "moderator" else None
     text = data.get("text", "")
     
@@ -2035,6 +2071,8 @@ def handle_voice_join(data):
     role = data.get("role", "unknown")
     client_id = data.get("client_id")
     participant_id = data.get("participant_id")
+    if role == ROLE_AUDITOR:
+        return {"status": "error", "message": "Read-only"}
     actor_participant_id = participant_id if role != "moderator" else None
     
     if not game_id:
@@ -2140,7 +2178,7 @@ def transcript():
     
     limit = int(request.args.get("limit", "200"))
     transcript_type = request.args.get("type", "all")
-    include_eliminations = bool(session.get("moderator"))
+    include_eliminations = is_staff()
     elimination_round_number = None
     if include_eliminations:
         game_state = get_game_state(game_id)

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,56 @@
+"""Staff authentication and authorization helpers."""
+
+from flask import session
+
+ROLE_MODERATOR = "moderator"
+ROLE_AUDITOR = "auditor"
+STAFF_ROLES = frozenset({ROLE_MODERATOR, ROLE_AUDITOR})
+
+
+def get_session_role():
+    """Return the logged-in staff role, or None."""
+    role = session.get("role")
+    if role in STAFF_ROLES:
+        return role
+    if session.get("moderator"):
+        return ROLE_MODERATOR
+    return None
+
+
+def is_moderator():
+    return get_session_role() == ROLE_MODERATOR
+
+
+def is_staff():
+    return get_session_role() in STAFF_ROLES
+
+
+def set_staff_session(role):
+    """Persist staff login in the Flask session."""
+    session["role"] = role
+    session["moderator"] = role == ROLE_MODERATOR
+
+
+def clear_staff_session():
+    session.pop("role", None)
+    session.pop("moderator", None)
+    session.pop("moderator_session_game_id", None)
+
+
+def authenticate_staff(role, password, moderator_password, auditor_password):
+    """Validate staff credentials. Returns True when login should succeed."""
+    if role == ROLE_MODERATOR:
+        return bool(moderator_password) and password == moderator_password
+    if role == ROLE_AUDITOR:
+        return bool(auditor_password) and password == auditor_password
+    return False
+
+
+def can_view_game(game_id, current_session_game_id):
+    """Return whether the current staff user may view a game."""
+    if not is_staff():
+        return False
+    if is_moderator():
+        return True
+    active_game_id = current_session_game_id()
+    return bool(active_game_id and game_id == active_game_id)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -221,13 +221,20 @@
     </header>
 
     <div class="control-panel">
-        <h1>🎮 Game Control Panel</h1>
+        <h1>{% if staff_role == 'auditor' %}👁️ Session Observer{% else %}🎮 Game Control Panel{% endif %}</h1>
+
+        {% if staff_role == 'auditor' %}
+        <div class="info-section" style="background:#fff8e1; border-color:#ffcc80;">
+            <strong>Read-only auditor mode.</strong> You can monitor the active session but cannot change game state, generate tokens, or send messages.
+        </div>
+        {% endif %}
 
         <div class="state-display" id="state-display">
             <h2>Current Status <div class="spinner"></div></h2>
             <div id="status-content">Loading...</div>
         </div>
 
+        {% if staff_role != 'auditor' %}
         <div class="control-buttons">
             <button id="btn-open" class="control-btn btn-open">🔓 Open Entry</button>
             <button id="btn-start" class="control-btn btn-start">▶️ Start Game</button>
@@ -276,6 +283,7 @@
                 Tokens are single-use and include a unique join URL. Download as CSV for distribution.
             </small>
         </div>
+        {% endif %}
 
         <div class="info-section" id="participant-section" style="display: none;">
             <h3>👥 Participants</h3>
@@ -288,7 +296,7 @@
         </div>
 
         <div class="footer">
-            <p>You are logged in as <strong>Moderator</strong>.</p>
+            <p>You are logged in as <strong>{{ 'Auditor (read-only)' if staff_role == 'auditor' else 'Moderator' }}</strong>.</p>
             <form action="/logout" method="get" style="display: inline;">
                 <button type="submit">🔒 Logout</button>
             </form>
@@ -296,6 +304,7 @@
     </div>
 
     <script>
+        const staffRole = {{ staff_role|tojson }};
         let currentState = null;
         let currentGameId = null;
 
@@ -305,11 +314,16 @@
                 const data = await res.json();
 
                 if (data.status === 'no_session') {
+                    const noSessionMessage = staffRole === 'auditor'
+                        ? 'No active session to observe. Wait for a moderator to open entry.'
+                        : 'Click "Open Entry" to create a new session';
                     document.getElementById('status-content').innerHTML = `
                         <div class="state-badge state-CLOSED">NO SESSION</div>
-                        <p>Click "Open Entry" to create a new session</p>
+                        <p>${noSessionMessage}</p>
                     `;
-                    updateButtons({ state: 'NO_SESSION', round_number: 1, can_swap_roles: false });
+                    if (staffRole !== 'auditor') {
+                        updateButtons({ state: 'NO_SESSION', round_number: 1, can_swap_roles: false });
+                    }
                 } else if (data.status === 'ok') {
                     currentState = data.state;
                     currentGameId = data.game_id;
@@ -359,16 +373,22 @@
                         gameLinksSection.style.display = 'block';
                         
                         const gameLinks = document.getElementById('game-links');
-                        gameLinks.innerHTML = `
+                        const observerLabel = staffRole === 'auditor' ? '👁️ Open Observer View' : '🖥️ Moderator Observer View';
+                        const playerLinks = staffRole === 'auditor' ? '' : `
                             <p><a href="/player1?game_id=${data.game_id}&participant_id=${data.player1_id}" target="_blank" class="link-btn">🎭 Player 1 View</a></p>
                             <p><a href="/player2?game_id=${data.game_id}&participant_id=${data.player2_id}" target="_blank" class="link-btn">🔍 Player 2 View</a></p>
-                            <p><a href="/moderator?game_id=${data.game_id}" target="_blank" class="link-btn">🖥️ Moderator Observer View</a></p>
+                        `;
+                        gameLinks.innerHTML = `
+                            ${playerLinks}
+                            <p><a href="/moderator?game_id=${data.game_id}" target="_blank" class="link-btn">${observerLabel}</a></p>
                         `;
                     } else {
                         document.getElementById('game-links-section').style.display = 'none';
                     }
 
-                    updateButtons(data);
+                    if (staffRole !== 'auditor') {
+                        updateButtons(data);
+                    }
                 }
             } catch (err) {
                 console.error('Status update failed:', err);
@@ -412,6 +432,7 @@
             }
         }
 
+        if (staffRole !== 'auditor') {
         document.getElementById('btn-open').onclick = async () => {
             try {
                 const res = await fetch('/moderator/control/open', { method: 'POST' });
@@ -550,6 +571,7 @@
             },
             successLabel: 'Check again',
         });
+        }
 
         updateStatus();
         setInterval(updateStatus, 2000);

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,14 +70,19 @@
 <body>
     <div class="login-box">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="GuessWho Logo" class="logo">
-        <h2>Moderator Login</h2>
+        <h2>Staff Login</h2>
 
         {% if error %}
         <p style="color: red;">Invalid password. Please try again.</p>
         {% endif %}
 
         <form method="POST" action="/login">
-            <input type="password" name="password" placeholder="Enter moderator password" required>
+            <label for="role" style="display:block; text-align:left; margin-bottom:8px; font-size:14px;">Role</label>
+            <select id="role" name="role" style="width:100%; padding:10px; margin-bottom:15px; border:1px solid #ccc; border-radius:6px; font-size:14px;">
+                <option value="moderator" {% if selected_role|default('moderator') == 'moderator' %}selected{% endif %}>Moderator</option>
+                <option value="auditor" {% if selected_role|default('moderator') == 'auditor' %}selected{% endif %}>Auditor (read-only)</option>
+            </select>
+            <input type="password" name="password" placeholder="Enter password" required>
             <button type="submit">Login</button>
         </form>
 

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -18,9 +18,15 @@
 
     <main class="moderator-main">
         <div class="header-bar">
-            <h2>Moderator View</h2>
+            <h2>{% if read_only %}Observer View{% else %}Moderator View{% endif %}</h2>
             <span class="game-info">Game ID: <span id="game-id-display">{{ game_id }}</span></span>
         </div>
+
+        {% if read_only %}
+        <p style="text-align:center; color:#856404; background:#fff8e1; padding:10px; border-radius:6px; max-width:720px; margin:0 auto 16px;">
+            Read-only auditor mode — chat and voice are disabled.
+        </p>
+        {% endif %}
 
         <div class="player-panels">
             <div class="player-box">
@@ -51,17 +57,21 @@
             <h3 class="chat-title">Chat</h3>
             <div id="transcript"></div>
 
+            {% if not read_only %}
             <div class="chat-bar">
                 <input type="text" id="chat-input" placeholder="Send a message to all participants">
                 <button id="send-chat">Send</button>
             </div>
+            {% endif %}
         </div>
 
+        {% if not read_only %}
         <div class="voice-controls" style="margin-top: 12px; display: flex; align-items: center; gap: 8px;">
             <button id="voice-toggle">Join voice</button>
             <span id="voice-status" style="color: #555;">idle</span>
             <audio id="remote-audio" hidden></audio>
         </div>
+        {% endif %}
 
         <footer>
             <p>Moderator controls and monitoring panel – GuessWho Stereotype</p>
@@ -72,11 +82,13 @@
     <script>
         // --- Setup -----------------------------------------------------
         const gameId = new URLSearchParams(window.location.search).get('game_id') || '{{ game_id }}';
+        const readOnly = {{ read_only|default(false)|tojson }};
+        const socketRole = readOnly ? "auditor" : "moderator";
         document.getElementById("game-id-display").textContent = gameId;
 
         // --- Socket setup ---------------------------------------------
         const socket = io();
-        socket.emit("join", {game_id: gameId, role: "moderator"});
+        socket.emit("join", {game_id: gameId, role: socketRole});
 
         const transcriptDiv = document.getElementById("transcript");
         const chatInput = document.getElementById("chat-input");
@@ -132,15 +144,16 @@
                         gameEnded = true;
                         if (voice) voice.stopVoice();
                         // Disable interactions
-                        document.getElementById('chat-input').disabled = true;
-                        document.getElementById('send-chat').disabled = true;
-                        document.getElementById('voice-toggle').disabled = true;
-                        document.getElementById('voice-toggle').style.opacity = '0.6';
-                        document.getElementById('voice-toggle').style.cursor = 'not-allowed';
-                        
-                        // Make chat bar visually inactive
-                        document.querySelector('.chat-bar').style.opacity = '0.6';
-                        document.getElementById('send-chat').style.cursor = 'not-allowed';
+                        if (!readOnly) {
+                            document.getElementById('chat-input').disabled = true;
+                            document.getElementById('send-chat').disabled = true;
+                            document.getElementById('voice-toggle').disabled = true;
+                            document.getElementById('voice-toggle').style.opacity = '0.6';
+                            document.getElementById('voice-toggle').style.cursor = 'not-allowed';
+                            const chatBar = document.querySelector('.chat-bar');
+                            if (chatBar) chatBar.style.opacity = '0.6';
+                            document.getElementById('send-chat').style.cursor = 'not-allowed';
+                        }
                         
                         const endNotification = document.createElement('div');
                         endNotification.style.cssText = 'position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #fff3cd; border: 2px solid #ffc107; padding: 30px; border-radius: 8px; text-align: center; font-size: 1.2em; font-weight: bold; color: #856404; z-index: 9999; width: 90%; max-width: 500px;';
@@ -207,20 +220,22 @@
         }
 
         // --- Chat send ------------------------------------------------
-        const sendChat = () => {
-            const text = chatInput.value.trim();
-            if (!text) return;
-            socket.emit("chat", {game_id: gameId, role: "moderator", text});
-            chatInput.value = "";
-        };
+        if (!readOnly && chatInput) {
+            const sendChat = () => {
+                const text = chatInput.value.trim();
+                if (!text) return;
+                socket.emit("chat", {game_id: gameId, role: "moderator", text});
+                chatInput.value = "";
+            };
 
-        document.getElementById("send-chat").onclick = sendChat;
-        chatInput.addEventListener("keydown", (event) => {
-            if (event.key === "Enter") {
-                event.preventDefault();
-                sendChat();
-            }
-        });
+            document.getElementById("send-chat").onclick = sendChat;
+            chatInput.addEventListener("keydown", (event) => {
+                if (event.key === "Enter") {
+                    event.preventDefault();
+                    sendChat();
+                }
+            });
+        }
 
         // --- Socket events --------------------------------------------
         socket.on("chat", data => appendMessage(`<b>${data.role}:</b> ${data.text}`));
@@ -257,16 +272,18 @@
         });
 
         // --- Voice (WebRTC) -------------------------------------------
-        voice = setupVoice({
-            socket,
-            gameId,
-            role: "moderator",
-            buttonEl: document.getElementById("voice-toggle"),
-            statusEl: document.getElementById("voice-status"),
-            remoteAudioEl: document.getElementById("remote-audio"),
-        });
-        if (MicCheck.isMicReady()) {
-            voice.startVoice();
+        if (!readOnly) {
+            voice = setupVoice({
+                socket,
+                gameId,
+                role: "moderator",
+                buttonEl: document.getElementById("voice-toggle"),
+                statusEl: document.getElementById("voice-status"),
+                remoteAudioEl: document.getElementById("remote-audio"),
+            });
+            if (MicCheck.isMicReady()) {
+                voice.startVoice();
+            }
         }
 
         socket.on('recording_start', (data) => {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ os.environ.setdefault('DB_PWD', 'xposed_pass')
 os.environ.setdefault('DB_NAME', 'xposed_db')
 os.environ.setdefault('SECRET_KEY', 'test-secret-key')
 os.environ.setdefault('MODERATOR_PASSWORD', 'test-password')
+os.environ.setdefault('AUDITOR_PASSWORD', 'test-auditor-password')
 
 from app import app, socketio, init_db
 
@@ -25,6 +26,7 @@ def ensure_test_password():
     """Ensure MODERATOR_PASSWORD is set to test value for all tests."""
     import app as app_module
     app_module.MODERATOR_PASSWORD = "test-password"
+    app_module.AUDITOR_PASSWORD = "test-auditor-password"
     yield
     # Restore after test (optional, but good practice)
 
@@ -131,45 +133,35 @@ def client(test_db):
     with app.test_client() as client:
         yield client
 
+def _reset_app_globals(app_module):
+    """Clear Redis and in-memory runtime state."""
+    if app_module.get_redis():
+        try:
+            redis_client = app_module.get_redis()
+            for key in redis_client.keys("game:*:state"):
+                redis_client.delete(key)
+            for key in redis_client.keys("roles:*"):
+                redis_client.delete(key)
+            for key in redis_client.keys("voice:*"):
+                redis_client.delete(key)
+            redis_client.delete("current_session_game_id")
+        except Exception as e:
+            print(f"Warning: Could not reset Redis: {e}")
+
+    app_module.GAME_STATES.clear()
+    app_module.CURRENT_SESSION_GAME_ID = None
+    app_module.PARTICIPANT_ROLES.clear()
+    app_module.VOICE_PARTICIPANTS.clear()
+
+
 @pytest.fixture
 def reset_globals():
     """Reset Redis and in-memory state between tests."""
     import app as app_module
-    
-    # Store originals for in-memory fallback
-    original_game_states = dict(app_module.GAME_STATES)
-    original_session_game_id = app_module.CURRENT_SESSION_GAME_ID
-    original_participant_roles = dict(app_module.PARTICIPANT_ROLES)
-    original_voice_participants = dict(app_module.VOICE_PARTICIPANTS)
-    
+
+    _reset_app_globals(app_module)
     yield
-    
-    # Reset Redis state if Redis is available
-    if app_module.get_redis():
-        try:
-            redis_client = app_module.get_redis()
-            # Clear all game state keys
-            for key in redis_client.keys("game:*:state"):
-                redis_client.delete(key)
-            # Clear all role keys
-            for key in redis_client.keys("roles:*"):
-                redis_client.delete(key)
-            # Clear all voice keys
-            for key in redis_client.keys("voice:*"):
-                redis_client.delete(key)
-            # Clear current session
-            redis_client.delete("current_session_game_id")
-        except Exception as e:
-            print(f"Warning: Could not reset Redis: {e}")
-    
-    # Reset in-memory fallback dicts
-    app_module.GAME_STATES.clear()
-    app_module.GAME_STATES.update(original_game_states)
-    app_module.CURRENT_SESSION_GAME_ID = original_session_game_id
-    app_module.PARTICIPANT_ROLES.clear()
-    app_module.PARTICIPANT_ROLES.update(original_participant_roles)
-    app_module.VOICE_PARTICIPANTS.clear()
-    app_module.VOICE_PARTICIPANTS.update(original_voice_participants)
+    _reset_app_globals(app_module)
 
 @pytest.fixture
 def socketio_client(test_db):

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -1,0 +1,164 @@
+import csv
+import io
+import json
+from urllib.parse import parse_qs, urlparse
+
+
+AUDITOR_PASSWORD = "test-auditor-password"
+MODERATOR_PASSWORD = "test-password"
+
+
+class TestAuditorAuth:
+    """Read-only auditor login and access controls."""
+
+    def extract_tokens_from_csv(self, csv_bytes):
+        csv_reader = csv.reader(io.StringIO(csv_bytes.decode("utf-8")))
+        rows = list(csv_reader)
+        tokens = []
+        for row in rows[1:]:
+            parsed = urlparse(row[0])
+            token = parse_qs(parsed.query).get("token", [None])[0]
+            assert token is not None
+            tokens.append(token)
+        return tokens
+
+    def auditor_login(self, client):
+        return client.post(
+            "/login",
+            data={"password": AUDITOR_PASSWORD, "role": "auditor"},
+        )
+
+    def moderator_login(self, client):
+        return client.post(
+            "/login",
+            data={"password": MODERATOR_PASSWORD, "role": "moderator"},
+        )
+
+    def test_auditor_login_success(self, client):
+        res = self.auditor_login(client)
+        assert res.status_code == 302
+        assert res.location.endswith("/dashboard")
+
+        res = client.get("/dashboard")
+        assert res.status_code == 200
+        assert b"Read-only auditor mode" in res.data
+
+    def test_auditor_login_rejects_wrong_password(self, client):
+        res = client.post(
+            "/login",
+            data={"password": "wrong-password", "role": "auditor"},
+        )
+        assert res.status_code == 200
+        assert b"Invalid password" in res.data
+
+    def test_auditor_cannot_access_dashboard_without_login(self, client):
+        res = client.get("/dashboard")
+        assert res.status_code == 302
+        assert res.location.endswith("/")
+
+    def test_auditor_can_read_status(self, client, reset_globals):
+        self.auditor_login(client)
+        res = client.get("/moderator/control/status")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert data["status"] == "no_session"
+
+    def test_auditor_cannot_open_entry(self, client, reset_globals):
+        self.auditor_login(client)
+        res = client.post("/moderator/control/open", json={})
+        assert res.status_code == 403
+
+    def test_auditor_cannot_generate_tokens(self, client, reset_globals):
+        self.auditor_login(client)
+        res = client.post("/moderator/tokens/generate", json={"count": 1})
+        assert res.status_code == 403
+
+    def test_auditor_cannot_start_or_end_game(self, client, reset_globals):
+        self.auditor_login(client)
+        assert client.post("/moderator/control/start", json={}).status_code == 403
+        assert client.post("/moderator/control/end", json={}).status_code == 403
+
+    def test_auditor_can_view_active_session(self, client, reset_globals):
+        self.moderator_login(client)
+        open_res = client.post("/moderator/control/open", json={})
+        game_id = json.loads(open_res.data)["game_id"]
+        client.get("/logout")
+
+        self.auditor_login(client)
+        res = client.get(f"/moderator?game_id={game_id}")
+        assert res.status_code == 200
+        assert b"Observer View" in res.data
+
+    def test_auditor_cannot_view_other_game_id(self, client, reset_globals):
+        self.moderator_login(client)
+        open_res = client.post("/moderator/control/open", json={})
+        active_game_id = json.loads(open_res.data)["game_id"]
+        client.get("/logout")
+
+        self.auditor_login(client)
+        other_game_id = "deadbeef" * 4
+        res = client.get(f"/moderator?game_id={other_game_id}")
+        assert res.status_code == 403
+
+        res = client.get(f"/transcript?game_id={active_game_id}&limit=50")
+        assert res.status_code == 200
+
+    def test_auditor_transcript_includes_eliminations(self, client, reset_globals):
+        self.moderator_login(client)
+        open_res = client.post("/moderator/control/open", json={})
+        game_id = json.loads(open_res.data)["game_id"]
+
+        tokens_res = client.post("/moderator/tokens/generate", json={"count": 2})
+        tokens = self.extract_tokens_from_csv(tokens_res.data)
+        client.post("/join/enter", json={"token": tokens[0]})
+        client.post("/join/enter", json={"token": tokens[1]})
+        client.post("/moderator/control/start", json={})
+        client.post("/eliminate_card", json={"game_id": game_id, "card_id": 4})
+
+        client.get("/logout")
+        self.auditor_login(client)
+
+        transcript_res = client.get(f"/transcript?game_id={game_id}&limit=200")
+        entries = json.loads(transcript_res.data)
+        assert any(
+            entry.get("action") == "eliminate" and entry.get("card") == 4
+            for entry in entries
+        )
+
+    def test_auditor_socket_chat_is_read_only(self, test_db, reset_globals):
+        from app import app, socketio, get_chat_history
+
+        from app import app
+
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret-key"
+        flask_client = app.test_client()
+        flask_client.post(
+            "/login",
+            data={"password": MODERATOR_PASSWORD, "role": "moderator"},
+        )
+        open_res = flask_client.post("/moderator/control/open", json={})
+        game_id = json.loads(open_res.data)["game_id"]
+        flask_client.get("/logout")
+
+        flask_client.post(
+            "/login",
+            data={"password": AUDITOR_PASSWORD, "role": "auditor"},
+        )
+        socketio_client = socketio.test_client(app, flask_test_client=flask_client)
+        try:
+            join_ack = socketio_client.emit(
+                "join", {"game_id": game_id, "role": "auditor"}, callback=True
+            )
+            assert join_ack != {"status": "error", "message": "Unauthorized"}
+            socketio_client.emit(
+                "chat",
+                {"game_id": game_id, "role": "auditor", "text": "should not send"},
+            )
+
+            chat_history = get_chat_history(game_id)
+            assert not any(
+                entry.get("text") == "should not send" for entry in chat_history
+            )
+        finally:
+            socketio_client.disconnect()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,7 @@ class TestAuth:
         """Test home page loads."""
         res = client.get("/")
         assert res.status_code == 200
-        assert b"Moderator Login" in res.data  # More precise; adjust to actual form title
+        assert b"Staff Login" in res.data
 
     @pytest.mark.parametrize("password, expected_status, expected_redirect, expected_content", [
         ("test-password", 302, "/dashboard", None),  # Success (uses fixture override)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -123,33 +123,44 @@ class TestChat:
         assert len(chat_events) > 0
         assert chat_events[0]['text'] == 'The person has brown hair.'
 
-    def test_moderator_send_chat(self, socketio_client, reset_globals, create_test_game):
+    def test_moderator_send_chat(self, test_db, reset_globals, create_test_game):
         """Test Moderator sending a chat message."""
-        from app import get_chat_history
-        
+        from app import app, socketio, get_chat_history
+
         game_id = "test-game-789"
-        
-        # Create game record in database first
         create_test_game(game_id)
-        
-        # Emit join event
-        socketio_client.emit('join', {
-            'game_id': game_id,
-            'role': 'moderator'
-        })
-        
-        # Emit chat message
-        socketio_client.emit('chat', {
-            'game_id': game_id,
-            'role': 'moderator',
-            'text': 'Good question. Please continue.'
-        })
-        
-        # Check that message was logged to chat table
-        chat_history = get_chat_history(game_id)
-        chat_events = [e for e in chat_history if e['role'] == 'moderator']
-        assert len(chat_events) > 0
-        assert chat_events[0]['text'] == 'Good question. Please continue.'
+
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret-key"
+        flask_client = app.test_client()
+        login_res = flask_client.post(
+            "/login",
+            data={"password": "test-password", "role": "moderator"},
+        )
+        assert login_res.status_code == 302
+        socketio_client = socketio.test_client(app, flask_test_client=flask_client)
+        try:
+            join_ack = socketio_client.emit(
+                "join", {"game_id": game_id, "role": "moderator"}, callback=True
+            )
+            chat_ack = socketio_client.emit(
+                "chat",
+                {
+                    "game_id": game_id,
+                    "role": "moderator",
+                    "text": "Good question. Please continue.",
+                },
+                callback=True,
+            )
+            assert join_ack != {"status": "error", "message": "Unauthorized"}, join_ack
+            assert chat_ack != {"status": "error", "message": "Unauthorized"}, chat_ack
+
+            chat_history = get_chat_history(game_id)
+            chat_events = [e for e in chat_history if e["role"] == "moderator"]
+            assert len(chat_events) > 0
+            assert chat_events[0]["text"] == "Good question. Please continue."
+        finally:
+            socketio_client.disconnect()
 
     def test_chat_message_missing_text(self, socketio_client, reset_globals, create_test_game):
         """Test sending chat without text field."""


### PR DESCRIPTION
- Introduce auth.py with session role helpers so future SSO/user-table auth can replace env passwords without touching route guards. 
- Auditors log in via AUDITOR_PASSWORD, can monitor session status and the live observer view, and receive transcripts with eliminations, but cannot mutate game state, generate tokens, chat, or join voice. 
- Socket and POST endpoints enforce read-only access server-side.

