### PR TITLE
Feature/coturn turn credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ from auth import (
     is_staff,
     set_staff_session,
 )
+from turn_config import build_ice_config
 
 load_dotenv()
 
@@ -2235,6 +2236,44 @@ def handle_webrtc_signal(data):
             print(f"Could not route signal: stale socket for {to_id} in game {game_id}")
     else:
         print(f"Could not route signal: to_id {to_id} not found in game {game_id}")
+
+
+# ---------------------------------------------------------------------
+# API: WebRTC ICE / TURN credentials
+# ---------------------------------------------------------------------
+@app.route("/api/webrtc/ice-servers")
+def webrtc_ice_servers():
+    """Return ICE servers for the browser (never includes TURN_SECRET).
+
+    Optional query params:
+    - user_id: included in minted TURN username for debugging (e.g. role)
+
+    Modes (see turn_config.build_ice_config):
+    - coturn: TURN_SERVER + TURN_SECRET set (time-limited credentials)
+    - public_fallback: secret unset and TURN_USE_PUBLIC_FALLBACK enabled (local)
+    - stun_only: no secret and public fallback disabled
+    """
+    user_id = request.args.get("user_id") or request.args.get("role")
+    try:
+        config = build_ice_config(user_id=user_id)
+    except ValueError as exc:
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+    # Do not log credentials; mode/server only for ops.
+    print(
+        f"WebRTC ICE config mode={config.get('mode')} "
+        f"server={config.get('server')} policy={config.get('iceTransportPolicy')}"
+    )
+    return jsonify(
+        {
+            "status": "ok",
+            "mode": config["mode"],
+            "iceServers": config["iceServers"],
+            "iceTransportPolicy": config["iceTransportPolicy"],
+            "ttl": config.get("ttl"),
+            "expires_at": config.get("expires_at"),
+        }
+    )
 
 
 # ---------------------------------------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,6 +108,21 @@ This page summarizes HTTP routes and Socket.IO events exposed by the application
   - Query: game_id, optional limit, optional type=all|events|chat
   - Returns combined or filtered transcript output.
 
+### WebRTC ICE / TURN
+
+- GET /api/webrtc/ice-servers
+  - Optional query: `user_id` or `role` (embedded in minted TURN username)
+  - Returns browser-safe ICE config (never includes `TURN_SECRET`):
+    - `mode`: `coturn` | `public_fallback` | `stun_only`
+    - `iceServers`: RTCIceServer list
+    - `iceTransportPolicy`: `all` | `relay`
+    - `ttl` / `expires_at`: present in `coturn` mode
+  - **Remote (coturn):** set `TURN_SERVER`, `TURN_PORT`, `TURN_SECRET` (same as
+    coturn `static-auth-secret`) in server env.
+  - **Local:** leave secret unset → public STUN/TURN fallback for LAN tests.
+  - Optional env: `TURN_USE_PUBLIC_FALLBACK`, `TURN_TTL_SECONDS`,
+    `TURN_TRANSPORTS`, `TURN_INCLUDE_PUBLIC_STUN`, `ICE_TRANSPORT_POLICY`.
+
 ## Socket.IO Events
 
 ### Client -> Server

--- a/static/webrtc.js
+++ b/static/webrtc.js
@@ -7,11 +7,9 @@
 // open pages with ?voice_debug=1 to loosen mic processing and log levels.
 
 (function () {
-  // Keep iceServers under 5 URLs (browser warning). Include TURN/TCP for
-  // restricted networks (VMs, campus firewalls) where host/srflx ICE fails.
-  const TURN_USER = "openrelayproject";
-  const TURN_PASS = "openrelayproject";
-  const ICE_SERVERS = [
+  // Fallback when /api/webrtc/ice-servers is unreachable (offline / old deploy).
+  // Prefer server-issued coturn credentials when TURN_SERVER + TURN_SECRET are set.
+  const PUBLIC_FALLBACK_ICE_SERVERS = [
     { urls: "stun:stun.l.google.com:19302" },
     {
       urls: [
@@ -19,8 +17,8 @@
         "turn:openrelay.metered.ca:443",
         "turn:openrelay.metered.ca:443?transport=tcp",
       ],
-      username: TURN_USER,
-      credential: TURN_PASS,
+      username: "openrelayproject",
+      credential: "openrelayproject",
     },
   ];
 
@@ -45,6 +43,51 @@
       opts.muteLabels || {}
     );
     const debug = voiceDebugEnabled();
+
+    // Loaded from GET /api/webrtc/ice-servers (coturn or public fallback).
+    let iceServers = PUBLIC_FALLBACK_ICE_SERVERS;
+    let iceTransportPolicy = "all";
+    let iceConfigMode = "public_fallback";
+    let iceConfigPromise = null;
+
+    async function loadIceConfig() {
+      if (iceConfigPromise) return iceConfigPromise;
+      iceConfigPromise = (async () => {
+        try {
+          const qs = role ? `?role=${encodeURIComponent(role)}` : "";
+          const res = await fetch(`/api/webrtc/ice-servers${qs}`, {
+            credentials: "same-origin",
+            cache: "no-store",
+          });
+          if (!res.ok) {
+            throw new Error(`ICE config HTTP ${res.status}`);
+          }
+          const data = await res.json();
+          if (!data || data.status === "error" || !Array.isArray(data.iceServers)) {
+            throw new Error((data && data.message) || "invalid ICE config");
+          }
+          iceServers = data.iceServers;
+          iceTransportPolicy =
+            data.iceTransportPolicy === "relay" ? "relay" : "all";
+          iceConfigMode = data.mode || "unknown";
+          console.log(`[WebRTC] ICE config loaded mode=${iceConfigMode}`, {
+            policy: iceTransportPolicy,
+            serverCount: iceServers.length,
+            ttl: data.ttl,
+          });
+        } catch (err) {
+          console.warn(
+            "[WebRTC] Failed to load ICE config from server; using public fallback",
+            err
+          );
+          iceServers = PUBLIC_FALLBACK_ICE_SERVERS;
+          iceTransportPolicy = "all";
+          iceConfigMode = "public_fallback_client";
+        }
+        return { iceServers, iceTransportPolicy, iceConfigMode };
+      })();
+      return iceConfigPromise;
+    }
 
     const participantStorageKey = `participant_id_${gameId}_${role}`;
     let participantId = localStorage.getItem(participantStorageKey);
@@ -447,7 +490,10 @@
     function createPeerConnection(peerId) {
       if (peers[peerId]) return peers[peerId];
 
-      const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+      const pc = new RTCPeerConnection({
+        iceServers,
+        iceTransportPolicy,
+      });
 
       pc.onicecandidate = (event) => {
         if (!event.candidate) {
@@ -712,6 +758,9 @@
           updateMuteButton();
           return;
         }
+
+        // Resolve ICE/TURN before joining the mesh (coturn creds or public fallback).
+        await loadIceConfig();
 
         if (!localStream) {
           // Same-machine multi-tab loopback is often silenced by AEC.

--- a/tests/test_turn_config.py
+++ b/tests/test_turn_config.py
@@ -1,0 +1,147 @@
+"""Unit tests for TURN credential minting and ICE config modes."""
+
+import base64
+import hashlib
+import hmac
+
+import pytest
+
+from turn_config import (
+    build_ice_config,
+    coturn_urls,
+    mint_turn_credentials,
+    public_fallback_ice_servers,
+)
+
+
+def test_mint_turn_credentials_hmac():
+    secret = "test-static-auth-secret"
+    creds = mint_turn_credentials(secret, ttl_seconds=3600, now=1_700_000_000)
+    assert creds["username"] == str(1_700_000_000 + 3600)
+    expected = base64.b64encode(
+        hmac.new(
+            secret.encode("utf-8"),
+            creds["username"].encode("utf-8"),
+            hashlib.sha1,
+        ).digest()
+    ).decode("ascii")
+    assert creds["credential"] == expected
+    assert creds["ttl"] == 3600
+    assert creds["expires_at"] == 1_700_000_000 + 3600
+
+
+def test_mint_turn_credentials_with_user_id():
+    creds = mint_turn_credentials(
+        "secret",
+        ttl_seconds=60,
+        user_id="player1",
+        now=1000,
+    )
+    assert creds["username"] == "1060:player1"
+
+
+def test_mint_requires_secret():
+    with pytest.raises(ValueError):
+        mint_turn_credentials("")
+
+
+def test_coturn_urls():
+    urls = coturn_urls("xposed-test.eur.nl", 3478, ["udp", "tcp"])
+    assert "stun:xposed-test.eur.nl:3478" in urls
+    assert "turn:xposed-test.eur.nl:3478?transport=udp" in urls
+    assert "turn:xposed-test.eur.nl:3478?transport=tcp" in urls
+
+
+def test_build_ice_config_coturn_mode():
+    cfg = build_ice_config(
+        user_id="moderator",
+        env={
+            "TURN_SERVER": "xposed-test.eur.nl",
+            "TURN_PORT": "3478",
+            "TURN_SECRET": "fe32secret",
+            "TURN_INCLUDE_PUBLIC_STUN": "0",
+            "ICE_TRANSPORT_POLICY": "all",
+        },
+    )
+    assert cfg["mode"] == "coturn"
+    assert cfg["server"] == "xposed-test.eur.nl"
+    assert cfg["port"] == 3478
+    assert cfg["ttl"]
+    assert cfg["expires_at"]
+    assert len(cfg["iceServers"]) == 1
+    entry = cfg["iceServers"][0]
+    assert entry["username"]
+    assert entry["credential"]
+    assert any(u.startswith("turn:") for u in entry["urls"])
+    # Secret must never appear in the payload
+    blob = str(cfg)
+    assert "fe32secret" not in blob
+
+
+def test_build_ice_config_public_fallback():
+    cfg = build_ice_config(env={})
+    assert cfg["mode"] == "public_fallback"
+    assert cfg["ttl"] is None
+    assert cfg["iceServers"] == public_fallback_ice_servers()
+
+
+def test_build_ice_config_stun_only_when_fallback_disabled():
+    cfg = build_ice_config(
+        env={
+            "TURN_USE_PUBLIC_FALLBACK": "0",
+        }
+    )
+    assert cfg["mode"] == "stun_only"
+    assert cfg["iceServers"][0]["urls"].startswith("stun:")
+
+
+def test_build_ice_config_relay_policy():
+    cfg = build_ice_config(
+        env={
+            "TURN_SERVER": "example.test",
+            "TURN_SECRET": "s",
+            "ICE_TRANSPORT_POLICY": "relay",
+            "TURN_INCLUDE_PUBLIC_STUN": "0",
+        }
+    )
+    assert cfg["iceTransportPolicy"] == "relay"
+
+
+def test_ice_servers_endpoint_public_fallback(monkeypatch):
+    """API returns public fallback when TURN_* is unset (no DB required)."""
+    monkeypatch.delenv("TURN_SERVER", raising=False)
+    monkeypatch.delenv("TURN_SECRET", raising=False)
+    monkeypatch.setenv("TURN_USE_PUBLIC_FALLBACK", "1")
+
+    from app import app
+
+    with app.test_client() as client:
+        res = client.get("/api/webrtc/ice-servers")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["status"] == "ok"
+    assert data["mode"] == "public_fallback"
+    assert isinstance(data["iceServers"], list)
+    assert len(data["iceServers"]) >= 1
+    assert "TURN_SECRET" not in str(data)
+
+
+def test_ice_servers_endpoint_coturn(monkeypatch):
+    monkeypatch.setenv("TURN_SERVER", "xposed-test.eur.nl")
+    monkeypatch.setenv("TURN_PORT", "3478")
+    monkeypatch.setenv("TURN_SECRET", "unit-test-secret")
+    monkeypatch.setenv("TURN_INCLUDE_PUBLIC_STUN", "0")
+
+    from app import app
+
+    with app.test_client() as client:
+        res = client.get("/api/webrtc/ice-servers?role=player1")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["status"] == "ok"
+    assert data["mode"] == "coturn"
+    entry = data["iceServers"][-1]
+    assert "username" in entry
+    assert "credential" in entry
+    assert "player1" in entry["username"]
+    assert "unit-test-secret" not in str(data)

--- a/turn_config.py
+++ b/turn_config.py
@@ -1,0 +1,251 @@
+"""TURN / ICE configuration for WebRTC.
+
+Supports two modes driven by environment variables:
+
+1. **Institutional coturn** (remote / VPN test)::
+
+       TURN_SERVER=xposed-test.eur.nl
+       TURN_PORT=3478
+       TURN_SECRET=<same as coturn static-auth-secret>
+
+   Mints time-limited credentials (coturn ``use-auth-secret`` / TURN REST).
+
+2. **Public fallback** (local mesh on a LAN / same machine)::
+
+       TURN_SERVER and TURN_SECRET unset (or empty)
+       TURN_USE_PUBLIC_FALLBACK=1   # default when secret missing
+
+   Uses Google STUN + public openrelay TURN (no server secret).
+
+The shared secret must never be sent to the browser — only short-lived
+username/credential pairs.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+
+# Public servers for local / unrestricted networks (no app secret).
+PUBLIC_STUN_URL = "stun:stun.l.google.com:19302"
+PUBLIC_TURN_URLS = [
+    "turn:openrelay.metered.ca:80",
+    "turn:openrelay.metered.ca:443",
+    "turn:openrelay.metered.ca:443?transport=tcp",
+]
+PUBLIC_TURN_USERNAME = "openrelayproject"
+PUBLIC_TURN_CREDENTIAL = "openrelayproject"
+
+DEFAULT_TURN_PORT = 3478
+DEFAULT_TTL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+def _env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return value
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = _env(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = _env(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def mint_turn_credentials(
+    secret: str,
+    *,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    user_id: Optional[str] = None,
+    now: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Create coturn ``use-auth-secret`` username/credential.
+
+    Username is ``<expiry_unix>`` or ``<expiry_unix>:<user_id>``.
+    Credential is Base64(HMAC-SHA1(secret, username)).
+    """
+    if not secret:
+        raise ValueError("TURN secret is required to mint credentials")
+
+    ttl = max(60, int(ttl_seconds))
+    expiry = int(now if now is not None else time.time()) + ttl
+    if user_id:
+        safe_id = "".join(c for c in str(user_id) if c.isalnum() or c in "-_")[:64]
+        username = f"{expiry}:{safe_id}" if safe_id else str(expiry)
+    else:
+        username = str(expiry)
+
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        username.encode("utf-8"),
+        hashlib.sha1,
+    ).digest()
+    credential = base64.b64encode(digest).decode("ascii")
+
+    return {
+        "username": username,
+        "credential": credential,
+        "ttl": ttl,
+        "expires_at": expiry,
+    }
+
+
+def coturn_urls(server: str, port: int, transports: Optional[List[str]] = None) -> List[str]:
+    """Build stun/turn URL list for a coturn host (kept small for browser ICE limits)."""
+    host = server.strip()
+    if not host:
+        return []
+    p = int(port) if port else DEFAULT_TURN_PORT
+    urls = [f"stun:{host}:{p}"]
+    tlist = transports or ["udp", "tcp"]
+    for transport in tlist:
+        t = transport.strip().lower()
+        if t == "udp":
+            urls.append(f"turn:{host}:{p}?transport=udp")
+        elif t == "tcp":
+            urls.append(f"turn:{host}:{p}?transport=tcp")
+        elif t:
+            urls.append(f"turn:{host}:{p}?transport={t}")
+    return urls
+
+
+def public_fallback_ice_servers() -> List[Dict[str, Any]]:
+    """ICE servers for local testing without institutional coturn."""
+    return [
+        {"urls": PUBLIC_STUN_URL},
+        {
+            "urls": list(PUBLIC_TURN_URLS),
+            "username": PUBLIC_TURN_USERNAME,
+            "credential": PUBLIC_TURN_CREDENTIAL,
+        },
+    ]
+
+
+def build_ice_config(
+    *,
+    user_id: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Build a browser-safe ICE config from environment.
+
+    Returns a dict suitable for JSON::
+
+        {
+          "mode": "coturn" | "public_fallback",
+          "iceServers": [...],
+          "iceTransportPolicy": "all" | "relay",
+          "ttl": int | null,
+          "expires_at": int | null,
+        }
+
+    Never includes TURN_SECRET.
+    """
+    # Allow tests to inject env without mutating os.environ permanently.
+    def get(name: str, default: Optional[str] = None) -> Optional[str]:
+        if env is not None:
+            if name not in env or env[name] in (None, ""):
+                return default
+            return env[name]
+        return _env(name, default)
+
+    def get_bool(name: str, default: bool) -> bool:
+        if env is not None:
+            if name not in env or env[name] in (None, ""):
+                return default
+            return str(env[name]).strip().lower() in ("1", "true", "yes", "on")
+        return _env_bool(name, default)
+
+    def get_int(name: str, default: int) -> int:
+        if env is not None:
+            raw = env.get(name)
+            if raw in (None, ""):
+                return default
+            try:
+                return int(raw)
+            except (TypeError, ValueError):
+                return default
+        return _env_int(name, default)
+
+    server = get("TURN_SERVER")
+    secret = get("TURN_SECRET")
+    port = get_int("TURN_PORT", DEFAULT_TURN_PORT)
+    ttl = get_int("TURN_TTL_SECONDS", DEFAULT_TTL_SECONDS)
+    policy = (get("ICE_TRANSPORT_POLICY", "all") or "all").strip().lower()
+    if policy not in ("all", "relay"):
+        policy = "all"
+
+    use_public = get_bool("TURN_USE_PUBLIC_FALLBACK", True)
+    include_public_stun = get_bool("TURN_INCLUDE_PUBLIC_STUN", True)
+
+    # Optional explicit URL list (comma-separated), advanced override.
+    custom_urls_raw = get("TURN_URLS")
+    transports_raw = get("TURN_TRANSPORTS", "udp,tcp") or "udp,tcp"
+    transports = [t.strip() for t in transports_raw.split(",") if t.strip()]
+
+    if server and secret:
+        if custom_urls_raw:
+            urls = [u.strip() for u in custom_urls_raw.split(",") if u.strip()]
+        else:
+            urls = coturn_urls(server, port, transports)
+
+        creds = mint_turn_credentials(secret, ttl_seconds=ttl, user_id=user_id)
+        ice_servers: List[Dict[str, Any]] = []
+        if include_public_stun:
+            ice_servers.append({"urls": PUBLIC_STUN_URL})
+        # One entry: coturn STUN + TURN URLs share the minted credentials.
+        ice_servers.append(
+            {
+                "urls": urls,
+                "username": creds["username"],
+                "credential": creds["credential"],
+            }
+        )
+        return {
+            "mode": "coturn",
+            "iceServers": ice_servers,
+            "iceTransportPolicy": policy,
+            "ttl": creds["ttl"],
+            "expires_at": creds["expires_at"],
+            "server": server,
+            "port": port,
+        }
+
+    if not use_public:
+        # Explicit: no coturn config and fallback disabled.
+        ice_servers = [{"urls": PUBLIC_STUN_URL}]
+        return {
+            "mode": "stun_only",
+            "iceServers": ice_servers,
+            "iceTransportPolicy": policy,
+            "ttl": None,
+            "expires_at": None,
+            "server": None,
+            "port": None,
+        }
+
+    return {
+        "mode": "public_fallback",
+        "iceServers": public_fallback_ice_servers(),
+        "iceTransportPolicy": policy,
+        "ttl": None,
+        "expires_at": None,
+        "server": None,
+        "port": None,
+    }


### PR DESCRIPTION
Wire the WebRTC client to institutional coturn using time-limited TURN credentials, while keeping a public STUN/TURN fallback for local development when coturn env vars are unset.

Voice on GSA/WireGuard failed at ICE because browsers could not rely on direct peer paths or public openrelay alone. Coturn is now available on the test VM (xposed-test.eur.nl:3478, use-auth-secret). This PR tells the app to mint credentials from TURN_SECRET and serve browser-safe ICE config via a new API.

Changes

• `turn_config.py` — mint coturn use-auth-secret credentials (HMAC-SHA1); build ICE config for coturn / public_fallback / stun_only modes
• `GET /api/webrtc/ice-servers` — returns iceServers, mode, ttl (never exposes TURN_SECRET)
• `static/webrtc.js` — loads ICE config before voice join; falls back to public STUN/TURN if the API is unavailable
• Tests for credential minting, modes, and the HTTP endpoint
• `docs/api.md` — documents the endpoint and env vars