### PR TITLE
Feature/media recorder

### DIFF
--- a/app.py
+++ b/app.py
@@ -1256,10 +1256,15 @@ def game_status():
             "message": "This game session is no longer active"
         })
 
+    recording_active = bool(game_state.get("recording_active"))
     return jsonify({
         "game_id": game_id,
         "state": game_state['state'],
-        "is_player": participant_id in [game_state.get('player1_id'), game_state.get('player2_id')]
+        "is_player": participant_id in [game_state.get('player1_id'), game_state.get('player2_id')],
+        "recording_active": recording_active,
+        "recording_id": game_state.get("recording_id") if recording_active else None,
+        "recording_server_ts": game_state.get("recording_server_ts") if recording_active else None,
+        "round_number": game_state.get("round_number", 1),
     })
 
 
@@ -1487,6 +1492,8 @@ def _stop_active_recording(game_id, game_state, reason="moderator_stop"):
     recording_id = game_state.get("recording_id")
     server_ts = _utc_iso_timestamp()
     game_state["recording_active"] = False
+    game_state["recording_id"] = None
+    game_state["recording_server_ts"] = None
     set_game_state(game_id, game_state)
 
     payload = {
@@ -1497,6 +1504,35 @@ def _stop_active_recording(game_id, game_state, reason="moderator_stop"):
     socketio.emit("recording_stop", payload, to=f"game:{game_id}")
     record_event("system", "recording_stop", game_id, text=reason)
     print(f"⏹️ Recording stopped for game {game_id} ({recording_id})")
+    return payload
+
+
+def _start_active_recording(game_id, game_state, reason="moderator_start"):
+    """Start a recording session and broadcast recording_start. Returns payload or None."""
+    if game_state.get("recording_active"):
+        return None
+
+    recording_id = uuid.uuid4().hex
+    server_ts = _utc_iso_timestamp()
+    game_state["recording_active"] = True
+    game_state["recording_id"] = recording_id
+    game_state["recording_server_ts"] = server_ts
+    set_game_state(game_id, game_state)
+
+    payload = {
+        "game_id": game_id,
+        "recording_id": recording_id,
+        "server_ts": server_ts,
+        "reason": reason,
+    }
+    socketio.emit("recording_start", payload, to=f"game:{game_id}")
+    record_event(
+        "system",
+        "recording_start",
+        game_id,
+        text=f"recording_id={recording_id}; reason={reason}",
+    )
+    print(f"⏺️ Recording started for game {game_id} ({recording_id}) reason={reason}")
     return payload
 
 
@@ -1759,6 +1795,15 @@ def moderator_swap_roles():
     if not old_player1_id or not old_player2_id:
         return jsonify({"status": "error", "message": "Missing player IDs"}), 400
 
+    # Close round-1 stems before pages navigate; open a new take for round 2 so
+    # the moderator only uses Start (game start) and Stop (game end).
+    was_recording = bool(game_state.get("recording_active"))
+    if was_recording:
+        _stop_active_recording(
+            moderator_game_id, game_state, reason="role_swap_end_segment"
+        )
+        game_state = get_game_state(moderator_game_id) or game_state
+
     # Read round 1 secret card before switching current round in game state
     previous_chosen_card = get_chosen_card(moderator_game_id)
 
@@ -1799,9 +1844,18 @@ def moderator_swap_roles():
             "round_number": 2,
             "player1_id": game_state['player1_id'],
             "player2_id": game_state['player2_id'],
+            "recording_will_resume": was_recording,
         },
         to=f"game:{moderator_game_id}",
     )
+
+    # New recording_id for round 2. Navigating clients resume via /game/status.
+    recording_payload = None
+    if was_recording:
+        game_state = get_game_state(moderator_game_id) or game_state
+        recording_payload = _start_active_recording(
+            moderator_game_id, game_state, reason="role_swap_start_segment"
+        )
 
     return jsonify({
         "status": "ok",
@@ -1809,6 +1863,8 @@ def moderator_swap_roles():
         "round_number": 2,
         "player1_url": f"/player1?game_id={moderator_game_id}&participant_id={game_state['player1_id']}",
         "player2_url": f"/player2?game_id={moderator_game_id}&participant_id={game_state['player2_id']}",
+        "recording_resumed": bool(recording_payload),
+        "recording_id": recording_payload.get("recording_id") if recording_payload else None,
     })
 
 
@@ -1863,31 +1919,17 @@ def moderator_recording_start():
     if game_state.get("recording_active"):
         return jsonify({"status": "error", "message": "Recording already active"}), 400
 
-    recording_id = uuid.uuid4().hex
-    server_ts = _utc_iso_timestamp()
-    game_state["recording_active"] = True
-    game_state["recording_id"] = recording_id
-    set_game_state(moderator_game_id, game_state)
-
-    payload = {
-        "game_id": moderator_game_id,
-        "recording_id": recording_id,
-        "server_ts": server_ts,
-    }
-    socketio.emit("recording_start", payload, to=f"game:{moderator_game_id}")
-    record_event(
-        "system",
-        "recording_start",
-        moderator_game_id,
-        text=f"recording_id={recording_id}",
+    payload = _start_active_recording(
+        moderator_game_id, game_state, reason="moderator_start"
     )
-    print(f"⏺️ Recording started for game {moderator_game_id} ({recording_id})")
+    if not payload:
+        return jsonify({"status": "error", "message": "Recording already active"}), 400
 
     return jsonify({
         "status": "ok",
         "game_id": moderator_game_id,
-        "recording_id": recording_id,
-        "server_ts": server_ts,
+        "recording_id": payload["recording_id"],
+        "server_ts": payload["server_ts"],
     })
 
 

--- a/static/recorder.js
+++ b/static/recorder.js
@@ -1,0 +1,343 @@
+// Session audio capture: each browser records its local microphone only.
+// Starts/stops on Socket.IO recording_start / recording_stop (no upload yet).
+//
+// Holds the last blob + sync timestamps for a later feature/audio-upload branch.
+
+(function () {
+  function pickMimeType() {
+    const candidates = [
+      "audio/webm;codecs=opus",
+      "audio/webm",
+      "audio/ogg;codecs=opus",
+      "audio/mp4",
+    ];
+    if (typeof MediaRecorder === "undefined") return "";
+    for (const type of candidates) {
+      if (MediaRecorder.isTypeSupported(type)) return type;
+    }
+    return "";
+  }
+
+  /**
+   * Clone local audio tracks so mute (track.enabled=false on the voice stream)
+   * does not silence the research recording, and so stopping the recorder does
+   * not tear down WebRTC tracks.
+   */
+  function cloneAudioStream(source) {
+    if (!source) return null;
+    const clones = source.getAudioTracks().map((track) => {
+      const c = track.clone();
+      c.enabled = true;
+      return c;
+    });
+    if (!clones.length) return null;
+    return new MediaStream(clones);
+  }
+
+  function stopStreamTracks(stream) {
+    if (!stream) return;
+    stream.getTracks().forEach((t) => {
+      try {
+        t.stop();
+      } catch (_) {}
+    });
+  }
+
+  /**
+   * @param {object} opts
+   * @param {object} opts.socket - Socket.IO client
+   * @param {string} opts.gameId
+   * @param {string} opts.role
+   * @param {string} [opts.participantId]
+   * @param {function(): MediaStream|null} [opts.getLocalStream]
+   * @param {function(): Promise<MediaStream|null>} [opts.ensureLocalStream]
+   * @param {HTMLElement|null} [opts.statusEl] - recording indicator
+   * @param {function(object): void} [opts.onComplete] - after stop with payload
+   */
+  function createSessionRecorder(opts) {
+    const socket = opts.socket;
+    const gameId = opts.gameId;
+    const role = opts.role || "unknown";
+    const participantId = opts.participantId || null;
+    const getLocalStream = opts.getLocalStream || (() => null);
+    const ensureLocalStream =
+      opts.ensureLocalStream ||
+      (async () => (typeof getLocalStream === "function" ? getLocalStream() : null));
+    const statusEl = opts.statusEl || null;
+    const onComplete = opts.onComplete || null;
+
+    let mediaRecorder = null;
+    let recStream = null;
+    let chunks = [];
+    let active = false;
+    let session = null; // metadata for current/last take
+    let lastResult = null;
+
+    function setIndicator(text, isRecording) {
+      if (!statusEl) return;
+      statusEl.textContent = text;
+      statusEl.style.color = isRecording ? "#b71c1c" : "#555";
+      statusEl.style.fontWeight = isRecording ? "600" : "normal";
+    }
+
+    function resetIndicator() {
+      setIndicator("", false);
+    }
+
+    function isRecording() {
+      return active && mediaRecorder && mediaRecorder.state === "recording";
+    }
+
+    function getLastResult() {
+      return lastResult;
+    }
+
+    /** Debug helper: download last take as a file in the browser. */
+    function downloadLast() {
+      if (!lastResult || !lastResult.blob) {
+        console.warn("[Recording] Nothing to download");
+        return false;
+      }
+      const ext = (lastResult.mimeType || "").includes("mp4")
+        ? "mp4"
+        : (lastResult.mimeType || "").includes("ogg")
+          ? "ogg"
+          : "webm";
+      const name = [
+        lastResult.recording_id || "rec",
+        role,
+        participantId || "anon",
+      ].join("_") + "." + ext;
+      const url = URL.createObjectURL(lastResult.blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = name;
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 2000);
+      return true;
+    }
+
+    async function startFromEvent(data) {
+      const clientReceivedTs = Date.now();
+
+      if (!data || data.game_id !== gameId) {
+        console.log("[Recording] ignore start for other game", data && data.game_id);
+        return { ok: false, reason: "wrong_game" };
+      }
+
+      if (isRecording()) {
+        console.warn("[Recording] already active; ignoring duplicate start");
+        return { ok: false, reason: "already_recording" };
+      }
+
+      if (typeof MediaRecorder === "undefined") {
+        console.error("[Recording] MediaRecorder not supported in this browser");
+        setIndicator("recording unsupported", false);
+        return { ok: false, reason: "unsupported" };
+      }
+
+      let local = typeof getLocalStream === "function" ? getLocalStream() : null;
+      if (!local || !local.getAudioTracks().length) {
+        try {
+          local = await ensureLocalStream();
+        } catch (err) {
+          console.error("[Recording] could not get microphone stream", err);
+          setIndicator("mic required for recording", false);
+          return { ok: false, reason: "no_mic" };
+        }
+      }
+      if (!local || !local.getAudioTracks().length) {
+        console.error("[Recording] no local audio tracks");
+        setIndicator("mic required for recording", false);
+        return { ok: false, reason: "no_mic" };
+      }
+
+      recStream = cloneAudioStream(local);
+      if (!recStream) {
+        setIndicator("mic required for recording", false);
+        return { ok: false, reason: "no_mic" };
+      }
+
+      const mimeType = pickMimeType();
+      chunks = [];
+      try {
+        mediaRecorder = mimeType
+          ? new MediaRecorder(recStream, { mimeType })
+          : new MediaRecorder(recStream);
+      } catch (err) {
+        console.error("[Recording] MediaRecorder construct failed", err);
+        stopStreamTracks(recStream);
+        recStream = null;
+        setIndicator("recorder error", false);
+        return { ok: false, reason: "construct_failed" };
+      }
+
+      session = {
+        game_id: gameId,
+        role,
+        participant_id: participantId,
+        recording_id: data.recording_id,
+        server_ts: data.server_ts,
+        client_received_ts: clientReceivedTs,
+        client_recorder_start_ts: null,
+        client_recorder_stop_ts: null,
+        mimeType: mediaRecorder.mimeType || mimeType || "",
+      };
+
+      mediaRecorder.ondataavailable = (ev) => {
+        if (ev.data && ev.data.size > 0) chunks.push(ev.data);
+      };
+
+      mediaRecorder.onerror = (ev) => {
+        console.error("[Recording] MediaRecorder error", ev.error || ev);
+      };
+
+      try {
+        // timeslice keeps data flowing; also helps some browsers flush chunks
+        mediaRecorder.start(1000);
+        session.client_recorder_start_ts = Date.now();
+        active = true;
+        setIndicator("⏺ recording…", true);
+        console.log("[Recording] started", {
+          recording_id: session.recording_id,
+          mimeType: session.mimeType,
+          server_ts: session.server_ts,
+          client_received_ts: session.client_received_ts,
+          client_recorder_start_ts: session.client_recorder_start_ts,
+        });
+        return { ok: true, session };
+      } catch (err) {
+        console.error("[Recording] start() failed", err);
+        stopStreamTracks(recStream);
+        recStream = null;
+        mediaRecorder = null;
+        session = null;
+        active = false;
+        setIndicator("recorder error", false);
+        return { ok: false, reason: "start_failed" };
+      }
+    }
+
+    function stopFromEvent(data) {
+      return new Promise((resolve) => {
+        if (data && data.game_id && data.game_id !== gameId) {
+          resolve({ ok: false, reason: "wrong_game" });
+          return;
+        }
+
+        if (!mediaRecorder || !active) {
+          console.log("[Recording] stop ignored (not recording)");
+          resolve({ ok: false, reason: "not_recording" });
+          return;
+        }
+
+        const mr = mediaRecorder;
+        const stopTs = Date.now();
+
+        mr.onstop = () => {
+          const mime =
+            (session && session.mimeType) || mr.mimeType || "audio/webm";
+          const blob = new Blob(chunks, { type: mime });
+          stopStreamTracks(recStream);
+          recStream = null;
+          chunks = [];
+          mediaRecorder = null;
+          active = false;
+
+          if (session) {
+            session.client_recorder_stop_ts = stopTs;
+            if (data && data.server_ts) {
+              session.server_stop_ts = data.server_ts;
+            }
+          }
+
+          lastResult = {
+            ...(session || {}),
+            blob,
+            size: blob.size,
+            mimeType: mime,
+          };
+          session = null;
+
+          setIndicator("recording saved (local)", false);
+          console.log("[Recording] stopped", {
+            recording_id: lastResult.recording_id,
+            size: lastResult.size,
+            mimeType: lastResult.mimeType,
+            client_recorder_start_ts: lastResult.client_recorder_start_ts,
+            client_recorder_stop_ts: lastResult.client_recorder_stop_ts,
+            server_ts: lastResult.server_ts,
+          });
+
+          if (typeof onComplete === "function") {
+            try {
+              onComplete(lastResult);
+            } catch (err) {
+              console.error("[Recording] onComplete error", err);
+            }
+          }
+
+          // Expose for manual debug / next upload branch
+          window.__lastRecording = lastResult;
+          resolve({ ok: true, result: lastResult });
+        };
+
+        try {
+          if (mr.state === "recording" || mr.state === "paused") {
+            mr.stop();
+          } else {
+            mr.onstop();
+          }
+        } catch (err) {
+          console.error("[Recording] stop() failed", err);
+          stopStreamTracks(recStream);
+          recStream = null;
+          mediaRecorder = null;
+          active = false;
+          session = null;
+          setIndicator("recorder error", false);
+          resolve({ ok: false, reason: "stop_failed" });
+        }
+      });
+    }
+
+    if (socket) {
+      socket.on("recording_start", (data) => {
+        startFromEvent(data).catch((err) =>
+          console.error("[Recording] start handler failed", err)
+        );
+      });
+      socket.on("recording_stop", (data) => {
+        stopFromEvent(data).catch((err) =>
+          console.error("[Recording] stop handler failed", err)
+        );
+      });
+      socket.on("game_ended", (data) => {
+        if (data && data.game_id && data.game_id !== gameId) return;
+        if (isRecording()) {
+          stopFromEvent(data || { game_id: gameId }).catch(() => {});
+        }
+      });
+    }
+
+    window.addEventListener("beforeunload", () => {
+      if (mediaRecorder && active) {
+        try {
+          mediaRecorder.stop();
+        } catch (_) {}
+        stopStreamTracks(recStream);
+      }
+    });
+
+    return {
+      startFromEvent,
+      stopFromEvent,
+      isRecording,
+      getLastResult,
+      downloadLast,
+      resetIndicator,
+    };
+  }
+
+  window.createSessionRecorder = createSessionRecorder;
+})();

--- a/static/recorder.js
+++ b/static/recorder.js
@@ -301,6 +301,52 @@
       });
     }
 
+    /**
+     * After role swap / reload, pages miss live socket events. If the server
+     * still has recording_active, start MediaRecorder for the current take.
+     */
+    async function resumeIfActive(maxAttempts) {
+      const attempts = maxAttempts || 8;
+      for (let i = 0; i < attempts; i++) {
+        if (isRecording()) {
+          return { ok: true, reason: "already_recording" };
+        }
+        try {
+          const res = await fetch(
+            `/game/status?game_id=${encodeURIComponent(gameId)}`,
+            { credentials: "same-origin", cache: "no-store" }
+          );
+          if (!res.ok) {
+            throw new Error(`status HTTP ${res.status}`);
+          }
+          const data = await res.json();
+          if (data.recording_active && data.recording_id) {
+            console.log("[Recording] resuming active take after load", {
+              recording_id: data.recording_id,
+              round_number: data.round_number,
+              attempt: i + 1,
+            });
+            const result = await startFromEvent({
+              game_id: gameId,
+              recording_id: data.recording_id,
+              server_ts:
+                data.recording_server_ts || new Date().toISOString(),
+              reason: "resume_after_load",
+            });
+            if (result && result.ok) return result;
+          } else if (i === 0) {
+            // Not active yet — may still be starting after role swap; retry.
+          } else if (!data.recording_active) {
+            return { ok: false, reason: "not_active" };
+          }
+        } catch (err) {
+          console.warn("[Recording] resumeIfActive poll failed", err);
+        }
+        await new Promise((r) => setTimeout(r, 400));
+      }
+      return { ok: false, reason: "give_up" };
+    }
+
     if (socket) {
       socket.on("recording_start", (data) => {
         startFromEvent(data).catch((err) =>
@@ -318,6 +364,13 @@
           stopFromEvent(data || { game_id: gameId }).catch(() => {});
         }
       });
+      // Prefer a clean stop before navigation on role swap (server also emits stop).
+      socket.on("roles_swapped", (data) => {
+        if (data && data.game_id && data.game_id !== gameId) return;
+        if (isRecording()) {
+          stopFromEvent(data).catch(() => {});
+        }
+      });
     }
 
     window.addEventListener("beforeunload", () => {
@@ -329,9 +382,15 @@
       }
     });
 
+    // Late join / post–role-swap pages reattach to an active take.
+    resumeIfActive().catch((err) =>
+      console.warn("[Recording] resumeIfActive failed", err)
+    );
+
     return {
       startFromEvent,
       stopFromEvent,
+      resumeIfActive,
       isRecording,
       getLastResult,
       downloadLast,

--- a/static/webrtc.js
+++ b/static/webrtc.js
@@ -916,7 +916,26 @@
       startVoice().catch((err) => console.error("Auto voice join failed:", err));
     }
 
-    return { startVoice, stopVoice, setMuted, toggleMute: () => setMuted(!isMuted) };
+    function getLocalStream() {
+      return localStream;
+    }
+
+    /** Ensure mic stream exists (for recording if voice not fully joined yet). */
+    async function ensureLocalStream() {
+      if (localStream) return localStream;
+      await startVoice();
+      return localStream;
+    }
+
+    return {
+      startVoice,
+      stopVoice,
+      setMuted,
+      toggleMute: () => setMuted(!isMuted),
+      getLocalStream,
+      ensureLocalStream,
+      isVoiceActive: () => voiceActive,
+    };
   }
 
   window.setupVoice = setupVoice;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -32,9 +32,31 @@
         .state-ENDED { background: #f3e5f5; color: #6a1b9a; }
         .control-buttons {
             display: flex;
-            gap: 15px;
-            flex-wrap: wrap;
+            flex-direction: column;
+            gap: 18px;
             margin: 20px 0;
+        }
+        .control-step {
+            background: #fafafa;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 14px 16px;
+        }
+        .control-step h3 {
+            margin: 0 0 6px;
+            font-size: 0.95em;
+            color: #333;
+        }
+        .control-step .step-note {
+            margin: 0 0 12px;
+            font-size: 0.85em;
+            color: #666;
+            line-height: 1.4;
+        }
+        .control-step-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
         }
         .control-btn {
             flex: 1;
@@ -109,18 +131,6 @@
             color: #c62828;
             font-size: 0.85em;
             font-weight: bold;
-        }
-        .recording-controls {
-            display: flex;
-            flex-direction: column;
-            gap: 15px;
-            flex: 1;
-            min-width: 150px;
-        }
-        .recording-controls .control-btn {
-            flex: 1;
-            width: 100%;
-            min-height: 52px;
         }
         .info-section {
             background: white;
@@ -236,18 +246,39 @@
 
         {% if staff_role != 'auditor' %}
         <div class="control-buttons">
-            <button id="btn-open" class="control-btn btn-open">🔓 Open Entry</button>
-            <button id="btn-start" class="control-btn btn-start">▶️ Start Game</button>
-            <button id="btn-swap" class="control-btn btn-start">🔁 Swap Roles</button>
-            <button id="btn-end" class="control-btn btn-end">⏹️ End Game</button>
-            <div class="recording-controls">
-                <button id="btn-record-start" class="control-btn btn-record-start">⏺️ Start Recording</button>
-                <button id="btn-record-stop" class="control-btn btn-record-stop">⏹️ Stop Recording</button>
+            <div class="control-step">
+                <h3>1 · Before the game</h3>
+                <p class="step-note">Open entry after tokens; check mic below; wait until 2 participants are ready.</p>
+                <div class="control-step-actions">
+                    <button id="btn-open" class="control-btn btn-open">🔓 Open Entry</button>
+                    <button id="btn-start" class="control-btn btn-start">▶️ Start Game</button>
+                </div>
             </div>
-            <p style="margin: 6px 0 0; font-size: 0.85em; color: #666; max-width: 28em;">
-                Start after the game begins; stop when the game ends.
-                Role swap auto-ends round&nbsp;1 takes and starts round&nbsp;2 — no extra click.
-            </p>
+
+            <div class="control-step">
+                <h3>2 · After the game has started</h3>
+                <p class="step-note">Start recording once everyone is in voice. Leave it running through both rounds.</p>
+                <div class="control-step-actions">
+                    <button id="btn-record-start" class="control-btn btn-record-start">⏺️ Start Recording</button>
+                </div>
+            </div>
+
+            <div class="control-step">
+                <h3>3 · During the game</h3>
+                <p class="step-note">Swap roles for round 2 — recording stops round&nbsp;1 stems and starts round&nbsp;2 automatically (no extra recording click).</p>
+                <div class="control-step-actions">
+                    <button id="btn-swap" class="control-btn btn-start">🔁 Swap Roles</button>
+                </div>
+            </div>
+
+            <div class="control-step">
+                <h3>4 · When finished</h3>
+                <p class="step-note">Stop recording first, then end the game session.</p>
+                <div class="control-step-actions">
+                    <button id="btn-record-stop" class="control-btn btn-record-stop">⏹️ Stop Recording</button>
+                    <button id="btn-end" class="control-btn btn-end">⏹️ End Game</button>
+                </div>
+            </div>
         </div>
 
         <div class="info-section">
@@ -261,13 +292,15 @@
         </div>
 
         <div class="info-section">
-            <h3>📋 Instructions</h3>
+            <h3>📋 Session workflow</h3>
             <ol>
-                <li><strong>Generate Tokens:</strong> Create invitation links for participants</li>
-                <li><strong>Open Entry:</strong> Allow participants to join via their unique links</li>
-                <li><strong>Wait:</strong> Exactly 2 participants must join (entry auto-closes)</li>
-                <li><strong>Start Game:</strong> Roles are assigned automatically and participants are redirected</li>
-                <li><strong>End Game:</strong> When game concludes, end the session</li>
+                <li><strong>Generate tokens</strong> and share join links</li>
+                <li><strong>Check microphone</strong>, then <strong>Open Entry</strong></li>
+                <li>Wait until <strong>2 participants</strong> have joined</li>
+                <li><strong>Start Game</strong> — open moderator view; wait for voice</li>
+                <li><strong>Start Recording</strong> — once only, after the game is running</li>
+                <li>Play round 1 → <strong>Swap Roles</strong> (recording continues into round 2 automatically)</li>
+                <li><strong>Stop Recording</strong>, then <strong>End Game</strong></li>
             </ol>
         </div>
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -244,6 +244,10 @@
                 <button id="btn-record-start" class="control-btn btn-record-start">⏺️ Start Recording</button>
                 <button id="btn-record-stop" class="control-btn btn-record-stop">⏹️ Stop Recording</button>
             </div>
+            <p style="margin: 6px 0 0; font-size: 0.85em; color: #666; max-width: 28em;">
+                Start after the game begins; stop when the game ends.
+                Role swap auto-ends round&nbsp;1 takes and starts round&nbsp;2 — no extra click.
+            </p>
         </div>
 
         <div class="info-section">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -33,102 +33,76 @@
         .control-buttons {
             display: flex;
             flex-direction: column;
-            gap: 18px;
+            gap: 12px;
             margin: 20px 0;
         }
         .control-step {
-            background: #fafafa;
-            border: 1px solid #e0e0e0;
-            border-radius: 8px;
-            padding: 14px 16px;
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            padding: 16px 18px;
+            border-left: 3px solid #0f766e;
         }
         .control-step h3 {
-            margin: 0 0 6px;
-            font-size: 0.95em;
-            color: #333;
+            margin: 0 0 4px;
+            font-size: 0.9em;
+            font-weight: 600;
+            color: #134e4a;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
         }
         .control-step .step-note {
-            margin: 0 0 12px;
-            font-size: 0.85em;
-            color: #666;
-            line-height: 1.4;
+            margin: 0 0 14px;
+            font-size: 0.88em;
+            color: #6b7280;
+            line-height: 1.45;
         }
         .control-step-actions {
             display: flex;
             flex-wrap: wrap;
-            gap: 12px;
+            gap: 10px;
         }
+        /* One shared button system — hierarchy via primary/secondary, not rainbow colours */
         .control-btn {
             flex: 1;
             min-width: 150px;
-            padding: 15px 20px;
-            font-size: 1em;
-            border: none;
-            border-radius: 5px;
+            padding: 12px 18px;
+            font-size: 0.95em;
+            border-radius: 8px;
             cursor: pointer;
-            font-weight: bold;
-            transition: all 0.3s;
+            font-weight: 600;
+            transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+            border: 1px solid #0f766e;
+            background: #0f766e;
+            color: #fff;
+        }
+        .control-btn:hover:not(:disabled) {
+            background: #0d9488;
+            border-color: #0d9488;
+            box-shadow: 0 1px 3px rgba(15, 118, 110, 0.25);
         }
         .control-btn:disabled {
             opacity: 0.4;
             cursor: not-allowed;
+            box-shadow: none;
         }
-        .btn-open {
-            background: #4CAF50;
-            color: white;
+        .control-btn.btn-secondary {
+            background: #fff;
+            color: #0f766e;
+            border-color: #99f6e4;
         }
-        .btn-open:hover:not(:disabled) {
-            background: #45a049;
-        }
-        .btn-close {
-            background: #f44336;
-            color: white;
-        }
-        .btn-close:hover:not(:disabled) {
-            background: #da190b;
-        }
-        .btn-start {
-            background: #2196F3;
-            color: white;
-        }
-        .btn-start:hover:not(:disabled) {
-            background: #0b7dda;
-        }
-        .btn-end {
-            background: #FF9800;
-            color: white;
-        }
-        .btn-end:hover:not(:disabled) {
-            background: #e68900;
-        }
-        .btn-reset {
-            background: #9E9E9E;
-            color: white;
-        }
-        .btn-reset:hover:not(:disabled) {
-            background: #757575;
-        }
-        .btn-record-start {
-            background: #c62828;
-            color: white;
-        }
-        .btn-record-start:hover:not(:disabled) {
-            background: #b71c1c;
-        }
-        .btn-record-stop {
-            background: #6a1b9a;
-            color: white;
-        }
-        .btn-record-stop:hover:not(:disabled) {
-            background: #4a148c;
+        .control-btn.btn-secondary:hover:not(:disabled) {
+            background: #f0fdfa;
+            border-color: #0f766e;
+            box-shadow: none;
         }
         .recording-badge {
             display: inline-block;
             margin-left: 10px;
             padding: 4px 10px;
             border-radius: 12px;
-            background: #ffebee;
-            color: #c62828;
+            background: #f0fdfa;
+            color: #0f766e;
             font-size: 0.85em;
             font-weight: bold;
         }
@@ -250,8 +224,8 @@
                 <h3>1 · Before the game</h3>
                 <p class="step-note">Open entry after tokens; check mic below; wait until 2 participants are ready.</p>
                 <div class="control-step-actions">
-                    <button id="btn-open" class="control-btn btn-open">🔓 Open Entry</button>
-                    <button id="btn-start" class="control-btn btn-start">▶️ Start Game</button>
+                    <button id="btn-open" class="control-btn btn-secondary btn-open">Open Entry</button>
+                    <button id="btn-start" class="control-btn btn-start">Start Game</button>
                 </div>
             </div>
 
@@ -259,15 +233,15 @@
                 <h3>2 · After the game has started</h3>
                 <p class="step-note">Start recording once everyone is in voice. Leave it running through both rounds.</p>
                 <div class="control-step-actions">
-                    <button id="btn-record-start" class="control-btn btn-record-start">⏺️ Start Recording</button>
+                    <button id="btn-record-start" class="control-btn btn-record-start">Start Recording</button>
                 </div>
             </div>
 
             <div class="control-step">
                 <h3>3 · During the game</h3>
-                <p class="step-note">Swap roles for round 2 — recording stops round&nbsp;1 stems and starts round&nbsp;2 automatically (no extra recording click).</p>
+                <p class="step-note">Swap roles for round 2 — recording ends the round&nbsp;1 take and starts round&nbsp;2 automatically.</p>
                 <div class="control-step-actions">
-                    <button id="btn-swap" class="control-btn btn-start">🔁 Swap Roles</button>
+                    <button id="btn-swap" class="control-btn btn-secondary btn-start">Swap Roles</button>
                 </div>
             </div>
 
@@ -275,8 +249,8 @@
                 <h3>4 · When finished</h3>
                 <p class="step-note">Stop recording first, then end the game session.</p>
                 <div class="control-step-actions">
-                    <button id="btn-record-stop" class="control-btn btn-record-stop">⏹️ Stop Recording</button>
-                    <button id="btn-end" class="control-btn btn-end">⏹️ End Game</button>
+                    <button id="btn-record-stop" class="control-btn btn-secondary btn-record-stop">Stop Recording</button>
+                    <button id="btn-end" class="control-btn btn-end">End Game</button>
                 </div>
             </div>
         </div>
@@ -311,9 +285,9 @@
                 <label for="token-count">Number of tokens:</label>
                 <input type="number" id="token-count" min="1" max="100" value="10" 
                        style="padding: 8px; width: 80px; border: 1px solid #ddd; border-radius: 4px;">
-                <button id="btn-generate-tokens" class="control-btn btn-open" 
+                <button id="btn-generate-tokens" class="control-btn btn-secondary btn-open"
                         style="flex: initial; min-width: 180px;">
-                    🎟️ Generate & Download
+                    Generate &amp; Download
                 </button>
             </div>
             <small style="color: #666; margin-top: 10px; display: block;">

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
     <script src="{{ url_for('static', filename='mic-check.js') }}"></script>
     <script src="{{ url_for('static', filename='webrtc.js') }}"></script>
+    <script src="{{ url_for('static', filename='recorder.js') }}"></script>
     <script src="{{ url_for('static', filename='endgame.js') }}"></script>
 </head>
 
@@ -69,6 +70,7 @@
         <div class="voice-controls" style="margin-top: 12px; display: flex; align-items: center; gap: 8px;">
             <button id="voice-mute" type="button" disabled>Mute</button>
             <span id="voice-status" style="color: #555;">connecting voice…</span>
+            <span id="recording-status"></span>
         </div>
         {% endif %}
 
@@ -294,14 +296,18 @@
                 statusEl: document.getElementById("voice-status"),
                 autoJoin: true,
             });
-        }
 
-        socket.on('recording_start', (data) => {
-            console.log('[Recording] started', data);
-        });
-        socket.on('recording_stop', (data) => {
-            console.log('[Recording] stopped', data);
-        });
+            const sessionRecorder = createSessionRecorder({
+                socket,
+                gameId,
+                role: "moderator",
+                participantId: null,
+                getLocalStream: () => voice && voice.getLocalStream(),
+                ensureLocalStream: () => voice && voice.ensureLocalStream(),
+                statusEl: document.getElementById("recording-status"),
+            });
+            window.sessionRecorder = sessionRecorder;
+        }
     </script>
 </body>
 

--- a/templates/player1.html
+++ b/templates/player1.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
     <script src="{{ url_for('static', filename='mic-check.js') }}"></script>
     <script src="{{ url_for('static', filename='webrtc.js') }}"></script>
+    <script src="{{ url_for('static', filename='recorder.js') }}"></script>
 </head>
 
 <body>
@@ -37,6 +38,7 @@
         <div class="voice-controls" style="margin-top: 10px;">
             <button id="voice-mute" type="button" disabled>Mute</button>
             <span id="voice-status" style="margin-left: 8px; color: #555;">spraak verbinden…</span>
+            <span id="recording-status" style="margin-left: 12px;"></span>
         </div>
     </main>
 
@@ -251,12 +253,17 @@
             autoJoin: true,
         });
 
-        socket.on('recording_start', (data) => {
-            console.log('[Recording] started', data);
+        // Local-mic capture only (separate stem per role). Upload comes later.
+        const sessionRecorder = createSessionRecorder({
+            socket,
+            gameId,
+            role: 'player1',
+            participantId,
+            getLocalStream: () => voice && voice.getLocalStream(),
+            ensureLocalStream: () => voice && voice.ensureLocalStream(),
+            statusEl: document.getElementById('recording-status'),
         });
-        socket.on('recording_stop', (data) => {
-            console.log('[Recording] stopped', data);
-        });
+        window.sessionRecorder = sessionRecorder;
     </script>
 </body>
 

--- a/templates/player2.html
+++ b/templates/player2.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
     <script src="{{ url_for('static', filename='mic-check.js') }}"></script>
     <script src="{{ url_for('static', filename='webrtc.js') }}"></script>
+    <script src="{{ url_for('static', filename='recorder.js') }}"></script>
     <script src="{{ url_for('static', filename='endgame.js') }}"></script>
 </head>
 
@@ -43,6 +44,7 @@
         <div class="voice-controls" style="margin-top: 10px;">
             <button id="voice-mute" type="button" disabled>Mute</button>
             <span id="voice-status" style="margin-left: 8px; color: #555;">spraak verbinden…</span>
+            <span id="recording-status" style="margin-left: 12px;"></span>
         </div>
     </main>
 
@@ -312,12 +314,16 @@
             autoJoin: true,
         });
 
-        socket.on('recording_start', (data) => {
-            console.log('[Recording] started', data);
+        const sessionRecorder = createSessionRecorder({
+            socket,
+            gameId,
+            role: 'player2',
+            participantId,
+            getLocalStream: () => voice && voice.getLocalStream(),
+            ensureLocalStream: () => voice && voice.ensureLocalStream(),
+            statusEl: document.getElementById('recording-status'),
         });
-        socket.on('recording_stop', (data) => {
-            console.log('[Recording] stopped', data);
-        });
+        window.sessionRecorder = sessionRecorder;
     </script>
 </body>
 


### PR DESCRIPTION
Summary

Add local MediaRecorder capture for each role (own mic only) on recording_start / recording_stop, and align the dashboard with the intended session flow.

Behaviour
• Start Recording / Stop Recording on the dashboard (start after game start; stop at end).
• Each of player1, player2, and moderator records a separate local stem (webm) with sync timestamps; blob kept in the browser (no upload yet).
• Role swap: auto-stop round‑1 take, start a new recording_id for round 2; new pages resume via /game/status.
• Dashboard: stepped workflow + unified teal button styling.

Out of scope
Server upload, disk storage, and audio_events rows.