### PR TITLE
Feature/audio upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ venv/
 .env
 .pytest_cache/
 data/game_log.json
+data/audio/
 nohup.out
 db/games.db
 site/

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Research web app for studying how people express stereotypes in a two-player ded
 | **Realtime** | Socket.IO chat, game events, voice signaling |
 | **Voice** | 3-way WebRTC mesh; mic check; auto-join; mute; coturn TURN via `GET /api/webrtc/ice-servers` |
 | **Recording control** | Moderator start/stop; `recording_start` / `recording_stop` to all roles |
-| **Local capture** | Each browser records its own mic (`static/recorder.js`); stems stay client-side until upload |
+| **Local capture + upload** | Each browser records its own mic and POSTs stems to `/audio/upload` (`AUDIO_STORAGE_DIR`) |
 | **Data** | MySQL/MariaDB persistence; Redis for live game/voice state |
 | **Deploy** | Gunicorn + gevent WebSocket worker; reverse-proxy friendly (ProxyFix) |
 
-Roadmap and next steps (audio upload + storage next): [docs/ROADMAP.md](docs/ROADMAP.md).  
+Roadmap and next steps (staging audio storage smoke test next): [docs/ROADMAP.md](docs/ROADMAP.md).  
 User guide, API, and more: [docs/](docs/) (MkDocs).
 
 ## Tech stack

--- a/app.py
+++ b/app.py
@@ -113,10 +113,18 @@ if not SECRET_KEY:
         "Please set it in your .env file or system environment."
     )
 
+# Local-mic research stems (POST /audio/upload). Staging may override path.
+AUDIO_STORAGE_DIR = os.path.abspath(
+    env_first("AUDIO_STORAGE_DIR", default=os.path.join(os.path.dirname(__file__), "data", "audio"))
+)
+# Cap per-request body (multipart stem + form fields). Override via env if needed.
+_AUDIO_MAX_UPLOAD_MB = _int_or_default(env_first("AUDIO_MAX_UPLOAD_MB", default="200"), 200)
+
 app.config.update(
     SECRET_KEY=SECRET_KEY,
     APP_NAME=env_first("APP_NAME", default="guesswho-stereotype"),
     TEMPLATES_AUTO_RELOAD=True,
+    MAX_CONTENT_LENGTH=_AUDIO_MAX_UPLOAD_MB * 1024 * 1024,
 )
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode="gevent")
 
@@ -243,13 +251,18 @@ def get_game_state(game_id):
         # Convert JSON fields and "null" sentinels
         if 'waiting_participants' in data:
             data['waiting_participants'] = json.loads(data['waiting_participants'])
+        if 'last_audio_uploads' in data and isinstance(data['last_audio_uploads'], str):
+            try:
+                data['last_audio_uploads'] = json.loads(data['last_audio_uploads'])
+            except (TypeError, ValueError, json.JSONDecodeError):
+                data['last_audio_uploads'] = None
         if 'round_number' in data:
             try:
                 data['round_number'] = int(data['round_number'])
             except (TypeError, ValueError):
                 data['round_number'] = 1
         # Convert "null" sentinels back to None
-        for key in ['player1_id', 'player2_id', 'recording_id']:
+        for key in ['player1_id', 'player2_id', 'recording_id', 'recording_server_ts']:
             if key in data and data[key] == "null":
                 data[key] = None
         if 'recording_active' in data:
@@ -483,6 +496,66 @@ GAME_STATES = {
 }
 CURRENT_SESSION_GAME_ID = None  # The active game session
 
+AUDIO_UPLOAD_ROLES = frozenset({"player1", "player2", "moderator"})
+
+
+def _ensure_audio_events_schema(cursor):
+    """Add audio_events columns/indexes on older DBs created before stem upload."""
+    cursor.execute(
+        """
+        SELECT COLUMN_NAME AS name
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audio_events'
+        """
+    )
+    cols = {row["name"] for row in cursor.fetchall()}
+    alters = []
+    if "recording_id" not in cols:
+        alters.append("ADD COLUMN recording_id VARCHAR(64) NULL")
+    if "role" not in cols:
+        alters.append("ADD COLUMN role VARCHAR(50) NULL")
+    if "client_received_ts" not in cols:
+        alters.append("ADD COLUMN client_received_ts BIGINT NULL")
+    if "client_recorder_start_ts" not in cols:
+        alters.append("ADD COLUMN client_recorder_start_ts BIGINT NULL")
+    if "client_recorder_stop_ts" not in cols:
+        alters.append("ADD COLUMN client_recorder_stop_ts BIGINT NULL")
+    if "server_start_ts" not in cols:
+        alters.append("ADD COLUMN server_start_ts VARCHAR(64) NULL")
+    if "server_stop_ts" not in cols:
+        alters.append("ADD COLUMN server_stop_ts VARCHAR(64) NULL")
+    if "mime_type" not in cols:
+        alters.append("ADD COLUMN mime_type VARCHAR(128) NULL")
+    if "byte_size" not in cols:
+        alters.append("ADD COLUMN byte_size INT NULL")
+    if "audio_path" in cols:
+        # Widen path for nested game_id/filename layout
+        alters.append("MODIFY COLUMN audio_path VARCHAR(512)")
+    for clause in alters:
+        try:
+            cursor.execute(f"ALTER TABLE audio_events {clause}")
+        except Exception as exc:
+            print(f"audio_events schema migrate skip ({clause}): {exc}")
+
+    cursor.execute(
+        """
+        SELECT INDEX_NAME AS name
+        FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'audio_events'
+        """
+    )
+    indexes = {row["name"] for row in cursor.fetchall()}
+    if "uq_audio_stem" not in indexes:
+        try:
+            cursor.execute(
+                """
+                ALTER TABLE audio_events
+                ADD UNIQUE KEY uq_audio_stem (game_id, recording_id, role)
+                """
+            )
+        except Exception as exc:
+            print(f"audio_events unique index migrate skip: {exc}")
+
 
 def init_db():
     """Ensure all tables exist before running the app."""
@@ -586,23 +659,36 @@ def init_db():
             """
         )
 
-        # Audio Events
+        # Audio Events (one row per local-mic stem per recording take)
         c.execute(
             """
             CREATE TABLE IF NOT EXISTS audio_events (
                 id INT AUTO_INCREMENT PRIMARY KEY,
                 game_id VARCHAR(255) NOT NULL,
+                recording_id VARCHAR(64) NOT NULL,
+                role VARCHAR(50) NOT NULL,
                 participant_id VARCHAR(255),
                 start_time DATETIME NOT NULL,
                 end_time DATETIME,
-                audio_path VARCHAR(255),
+                client_received_ts BIGINT,
+                client_recorder_start_ts BIGINT,
+                client_recorder_stop_ts BIGINT,
+                server_start_ts VARCHAR(64),
+                server_stop_ts VARCHAR(64),
+                audio_path VARCHAR(512),
+                mime_type VARCHAR(128),
+                byte_size INT,
                 transcript TEXT,
                 timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_audio_stem (game_id, recording_id, role),
                 FOREIGN KEY (game_id) REFERENCES games(id) ON DELETE CASCADE,
-                FOREIGN KEY (participant_id) REFERENCES participants(id)
+                FOREIGN KEY (participant_id) REFERENCES participants(id),
+                INDEX idx_audio_game (game_id),
+                INDEX idx_audio_recording (recording_id)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
             """
         )
+        _ensure_audio_events_schema(c)
         
         # Chat Messages
         c.execute(
@@ -1494,6 +1580,12 @@ def _stop_active_recording(game_id, game_state, reason="moderator_stop"):
     game_state["recording_active"] = False
     game_state["recording_id"] = None
     game_state["recording_server_ts"] = None
+    # Fresh stem checklist for this take (clients upload after stop).
+    game_state["last_audio_uploads"] = {
+        "recording_id": recording_id,
+        "server_stop_ts": server_ts,
+        "stems": {},
+    }
     set_game_state(game_id, game_state)
 
     payload = {
@@ -1589,6 +1681,7 @@ def moderator_control_status():
         "player2_id": game_state.get('player2_id'),
         "recording_active": bool(game_state.get("recording_active")),
         "recording_id": game_state.get("recording_id") if game_state.get("recording_active") else None,
+        "last_audio_uploads": game_state.get("last_audio_uploads"),
     })
 
 
@@ -1958,6 +2051,290 @@ def moderator_recording_stop():
         "game_id": moderator_game_id,
         "recording_id": payload.get("recording_id") if payload else None,
         "server_ts": payload.get("server_ts") if payload else None,
+    })
+
+
+def _parse_client_ts(value):
+    """Parse required client epoch-ms timestamp from form fields."""
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ms_to_datetime(ms):
+    """Convert epoch milliseconds to naive UTC datetime for DATETIME columns."""
+    return datetime.datetime.fromtimestamp(ms / 1000.0, tz=datetime.timezone.utc).replace(
+        tzinfo=None
+    )
+
+
+def _safe_audio_filename_part(value, fallback="none"):
+    """Sanitize a path segment for stem filenames."""
+    if value is None or value == "":
+        return fallback
+    text = str(value)
+    cleaned = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in text)
+    return cleaned[:80] or fallback
+
+
+def _authorize_audio_upload(game_id, role, participant_id, game_state):
+    """Soft auth for stem upload. Returns (ok, error_message, http_status)."""
+    if role not in AUDIO_UPLOAD_ROLES:
+        return False, "Invalid role", 400
+
+    state = game_state.get("state")
+    if state not in ("IN_PROGRESS", "ENDED"):
+        return False, f"Uploads not allowed in state: {state}", 400
+
+    if role == "moderator":
+        if not is_moderator():
+            return False, "Unauthorized", 403
+        # Prefer the moderator's bound session game; allow if it matches.
+        mod_game = session.get("moderator_session_game_id") or get_current_session_game_id()
+        if mod_game and mod_game != game_id:
+            return False, "game_id does not match moderator session", 403
+        return True, None, 200
+
+    if not participant_id:
+        return False, "participant_id required for player uploads", 400
+
+    # After role swap, player1_id/player2_id flip before late uploads arrive.
+    # Accept either assigned participant; trust client role as the stem label for
+    # the take that was just recorded on that page.
+    assigned = {game_state.get("player1_id"), game_state.get("player2_id")}
+    if participant_id not in assigned:
+        return False, "participant_id is not assigned to this game", 403
+
+    return True, None, 200
+
+
+def _record_audio_upload_status(game_id, game_state, recording_id, role, stem_info):
+    """Update last_audio_uploads checklist in game state after a successful save."""
+    uploads = game_state.get("last_audio_uploads")
+    if not isinstance(uploads, dict) or uploads.get("recording_id") != recording_id:
+        uploads = {
+            "recording_id": recording_id,
+            "server_stop_ts": None,
+            "stems": {},
+        }
+    stems = dict(uploads.get("stems") or {})
+    stems[role] = stem_info
+    uploads["stems"] = stems
+    game_state["last_audio_uploads"] = uploads
+    set_game_state(game_id, game_state)
+    return uploads
+
+
+@app.route("/audio/upload", methods=["POST"])
+def audio_upload():
+    """Accept a local-mic stem for a recording take (multipart).
+
+    Expected form fields:
+      file, game_id, recording_id, role, participant_id (optional for moderator),
+      client_received_ts, client_recorder_start_ts, client_recorder_stop_ts,
+      server_ts, server_stop_ts (optional), mime_type (optional)
+    """
+    game_id = (request.form.get("game_id") or "").strip()
+    recording_id = (request.form.get("recording_id") or "").strip()
+    role = (request.form.get("role") or "").strip()
+    participant_id = (request.form.get("participant_id") or "").strip() or None
+
+    if not game_id or not recording_id or not role:
+        return jsonify({
+            "status": "error",
+            "message": "game_id, recording_id, and role are required",
+        }), 400
+
+    client_received_ts = _parse_client_ts(request.form.get("client_received_ts"))
+    client_start_ts = _parse_client_ts(request.form.get("client_recorder_start_ts"))
+    client_stop_ts = _parse_client_ts(request.form.get("client_recorder_stop_ts"))
+    if client_received_ts is None or client_start_ts is None or client_stop_ts is None:
+        return jsonify({
+            "status": "error",
+            "message": "client_received_ts, client_recorder_start_ts, and client_recorder_stop_ts are required",
+        }), 400
+    if client_stop_ts < client_start_ts:
+        return jsonify({
+            "status": "error",
+            "message": "client_recorder_stop_ts must be >= client_recorder_start_ts",
+        }), 400
+
+    game_state = get_game_state(game_id)
+    if not game_state:
+        return jsonify({"status": "error", "message": "Unknown game_id"}), 404
+
+    ok, err, status = _authorize_audio_upload(game_id, role, participant_id, game_state)
+    if not ok:
+        return jsonify({"status": "error", "message": err}), status
+
+    upload = request.files.get("file")
+    if upload is None or not upload.filename:
+        return jsonify({"status": "error", "message": "file is required"}), 400
+
+    raw = upload.read()
+    if not raw:
+        return jsonify({"status": "error", "message": "empty audio file"}), 400
+
+    mime_type = (request.form.get("mime_type") or upload.mimetype or "audio/webm").strip()
+    server_start_ts = (request.form.get("server_ts") or "").strip() or None
+    server_stop_ts = (request.form.get("server_stop_ts") or "").strip() or None
+
+    # Extension from mime (default webm)
+    if "ogg" in mime_type:
+        ext = "ogg"
+    elif "mp4" in mime_type or "m4a" in mime_type:
+        ext = "m4a"
+    else:
+        ext = "webm"
+
+    participant_part = _safe_audio_filename_part(
+        participant_id if role != "moderator" else "moderator",
+        fallback="none",
+    )
+    safe_recording = _safe_audio_filename_part(recording_id, fallback="recording")
+    safe_role = _safe_audio_filename_part(role, fallback="role")
+    safe_game = _safe_audio_filename_part(game_id, fallback="game")
+
+    rel_name = f"{safe_recording}_{safe_role}_{participant_part}.{ext}"
+    game_dir = os.path.join(AUDIO_STORAGE_DIR, safe_game)
+    os.makedirs(game_dir, exist_ok=True)
+    abs_path = os.path.join(game_dir, rel_name)
+    part_path = abs_path + ".part"
+
+    try:
+        with open(part_path, "wb") as fh:
+            fh.write(raw)
+        os.replace(part_path, abs_path)
+    except OSError as exc:
+        try:
+            if os.path.exists(part_path):
+                os.remove(part_path)
+        except OSError:
+            pass
+        print(f"audio upload write failed: {exc}")
+        return jsonify({"status": "error", "message": "failed to store audio"}), 500
+
+    # Path stored relative to AUDIO_STORAGE_DIR for portability
+    audio_path = f"{safe_game}/{rel_name}"
+    start_time = _ms_to_datetime(client_start_ts)
+    end_time = _ms_to_datetime(client_stop_ts)
+    byte_size = len(raw)
+
+    try:
+        with get_db_conn() as conn:
+            c = conn.cursor()
+            if participant_id:
+                c.execute(
+                    "INSERT INTO participants (id) VALUES (%s) ON DUPLICATE KEY UPDATE id=id",
+                    (participant_id,),
+                )
+            # Ensure parent game row exists for FK (tests / recovery)
+            c.execute(
+                "INSERT INTO games (id) VALUES (%s) ON DUPLICATE KEY UPDATE id=id",
+                (game_id,),
+            )
+            c.execute(
+                """
+                INSERT INTO audio_events (
+                    game_id, recording_id, role, participant_id,
+                    start_time, end_time,
+                    client_received_ts, client_recorder_start_ts, client_recorder_stop_ts,
+                    server_start_ts, server_stop_ts,
+                    audio_path, mime_type, byte_size
+                ) VALUES (
+                    %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s, %s,
+                    %s, %s,
+                    %s, %s, %s
+                )
+                ON DUPLICATE KEY UPDATE
+                    participant_id = VALUES(participant_id),
+                    start_time = VALUES(start_time),
+                    end_time = VALUES(end_time),
+                    client_received_ts = VALUES(client_received_ts),
+                    client_recorder_start_ts = VALUES(client_recorder_start_ts),
+                    client_recorder_stop_ts = VALUES(client_recorder_stop_ts),
+                    server_start_ts = VALUES(server_start_ts),
+                    server_stop_ts = VALUES(server_stop_ts),
+                    audio_path = VALUES(audio_path),
+                    mime_type = VALUES(mime_type),
+                    byte_size = VALUES(byte_size),
+                    timestamp = CURRENT_TIMESTAMP
+                """,
+                (
+                    game_id,
+                    recording_id,
+                    role,
+                    participant_id,
+                    start_time,
+                    end_time,
+                    client_received_ts,
+                    client_start_ts,
+                    client_stop_ts,
+                    server_start_ts,
+                    server_stop_ts,
+                    audio_path,
+                    mime_type,
+                    byte_size,
+                ),
+            )
+            c.execute(
+                """
+                SELECT id FROM audio_events
+                WHERE game_id = %s AND recording_id = %s AND role = %s
+                """,
+                (game_id, recording_id, role),
+            )
+            row = c.fetchone()
+            audio_event_id = row["id"] if row else None
+    except Exception as exc:
+        print(f"audio_events insert failed: {exc}")
+        return jsonify({"status": "error", "message": "failed to record audio event"}), 500
+
+    stem_info = {
+        "status": "ok",
+        "participant_id": participant_id,
+        "byte_size": byte_size,
+        "audio_path": audio_path,
+        "mime_type": mime_type,
+    }
+    # Refresh state in case stop initialized checklist after we loaded it
+    game_state = get_game_state(game_id) or game_state
+    uploads = _record_audio_upload_status(
+        game_id, game_state, recording_id, role, stem_info
+    )
+
+    payload = {
+        "game_id": game_id,
+        "recording_id": recording_id,
+        "role": role,
+        "participant_id": participant_id,
+        "audio_path": audio_path,
+        "byte_size": byte_size,
+        "audio_event_id": audio_event_id,
+    }
+    socketio.emit("audio_upload_complete", payload, to=f"game:{game_id}")
+    record_event(
+        role,
+        "audio_upload",
+        game_id,
+        text=f"recording_id={recording_id}; path={audio_path}; bytes={byte_size}",
+        participant_id=participant_id,
+    )
+    print(f"🎤 Audio uploaded {game_id}/{rel_name} ({byte_size} bytes)")
+
+    return jsonify({
+        "status": "ok",
+        "audio_path": audio_path,
+        "audio_event_id": audio_event_id,
+        "byte_size": byte_size,
+        "recording_id": recording_id,
+        "role": role,
+        "last_audio_uploads": uploads,
     })
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Development milestones for the *Xposed* web application (Guess Who–style resea
 |-------|--------|
 | 1 – Core MVP | Done |
 | 2 – First game playable | Done |
-| 3 – Live voice + recording | **In progress** — voice + local capture done; **next: audio upload** |
+| 3 – Live voice + recording | **In progress** — capture + upload done; **next: staging storage smoke test** |
 | 4 – Deployment & security | Mostly done (hardening ongoing) |
 | 5 – Research features | Future |
 
@@ -75,13 +75,17 @@ Shipped in `feature/media-recorder` (`static/recorder.js` on player1, player2, m
 - [x] Track cloning so voice mute does not silence research stems  
 - [x] Auto-segment on role swap; resume active take via `/game/status`  
 
-### Upload & storage — in progress (next)
+### Upload & storage — in progress
 
-- [ ] `POST /audio/upload` (multipart: file + metadata)  
-- [ ] Path pattern: `{game_id}/{recording_id}_{role}_{participant_id}.webm`  
-- [ ] Env `AUDIO_STORAGE_DIR` (local `data/audio/`; staging e.g. `/data/xposed/shared/audio/`)  
-- [ ] Insert `audio_events` with path + start/end times  
-- [ ] Reject uploads missing required timestamps  
+- [x] `POST /audio/upload` (multipart: file + metadata)  
+- [x] Path pattern: `{game_id}/{recording_id}_{role}_{participant_id}.webm`  
+- [x] Env `AUDIO_STORAGE_DIR` (local `data/audio/`; staging e.g. `/data/xposed/shared/audio/`)  
+- [x] Insert `audio_events` with path + start/end + client timestamps  
+- [x] Reject uploads missing required timestamps  
+- [x] Idempotent overwrite per `(game_id, recording_id, role)`  
+- [x] Local success/fail UI; `audio_upload_complete` socket event  
+- [x] Dashboard informational stem checklist (`last_audio_uploads`)  
+- [x] Wait for **own** upload before role-swap navigation / end teardown (option 1 soft gate)  
 - [ ] Staging directory, deploy env, full-session smoke test  
 
 ---
@@ -114,7 +118,7 @@ Shipped in `feature/media-recorder` (`static/recorder.js` on player1, player2, m
 ## Suggested order of work
 
 1. ~~**`feature/media-recorder`** — record local mic on all roles when moderator starts recording~~ **done**  
-2. **`feature/audio-upload`** — upload webm + timestamps; persist `audio_events`  
+2. ~~**`feature/audio-upload`** — upload webm + timestamps; persist `audio_events`~~ **done** (option 1 soft gate)  
 3. **`chore/audio-storage-staging`** — VM directory, env, full pipeline smoke test  
 4. Hardening / reconnection and research tooling as needed  
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -93,13 +93,23 @@ This page summarizes HTTP routes and Socket.IO events exposed by the application
   - Broadcasts recording_start to room game:{game_id}.
   - Response includes recording_id and server_ts (UTC ISO-8601).
   - Clients (player1, player2, moderator) start local-mic MediaRecorder on this event.
-  - Audio is not uploaded yet (no POST /audio/upload); stems remain in the browser.
 
 - POST /moderator/control/recording/stop
   - Stops the active recording session.
   - Broadcasts recording_stop to room game:{game_id}.
   - Idempotent when no recording is active (returns ok).
-  - Clients stop MediaRecorder and keep the last blob + timestamps locally.
+  - Clients stop MediaRecorder and POST the stem to /audio/upload.
+
+- POST /audio/upload
+  - Multipart form: `file` plus metadata fields:
+    - required: `game_id`, `recording_id`, `role`,
+      `client_received_ts`, `client_recorder_start_ts`, `client_recorder_stop_ts`
+    - optional: `participant_id` (required for players), `server_ts`, `server_stop_ts`, `mime_type`
+  - Auth (soft): players must be assigned to the game; moderator requires staff session.
+  - Stores under `AUDIO_STORAGE_DIR/{game_id}/{recording_id}_{role}_{participant}.webm`
+  - Upserts `audio_events` (unique on game_id + recording_id + role).
+  - Broadcasts `audio_upload_complete` to room `game:{game_id}`.
+  - Updates game state `last_audio_uploads` for dashboard checklist.
 
 - POST /moderator/tokens/generate
   - Body: {"count": 1..100}
@@ -162,7 +172,10 @@ This page summarizes HTTP routes and Socket.IO events exposed by the application
   - Clients record local microphone only (not remote WebRTC audio).
 - recording_stop
   - Payload: {"game_id", "recording_id", "server_ts"}
-  - Clients finalize the local stem; server persistence is planned (see ROADMAP).
+  - Clients finalize the local stem and upload to POST /audio/upload.
+- audio_upload_complete
+  - Payload: {"game_id", "recording_id", "role", "participant_id", "audio_path", "byte_size", "audio_event_id"}
+  - Emitted after a successful stem save.
 - game_ended
   - Payload: {"game_id", "state"}
   - Clients should leave voice when received.

--- a/static/recorder.js
+++ b/static/recorder.js
@@ -1,7 +1,6 @@
 // Session audio capture: each browser records its local microphone only.
-// Starts/stops on Socket.IO recording_start / recording_stop (no upload yet).
-//
-// Holds the last blob + sync timestamps for a later feature/audio-upload branch.
+// Starts/stops on Socket.IO recording_start / recording_stop, then uploads
+// the stem to POST /audio/upload (option 1: soft gate + notifications).
 
 (function () {
   function pickMimeType() {
@@ -43,6 +42,10 @@
     });
   }
 
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
   /**
    * @param {object} opts
    * @param {object} opts.socket - Socket.IO client
@@ -52,7 +55,9 @@
    * @param {function(): MediaStream|null} [opts.getLocalStream]
    * @param {function(): Promise<MediaStream|null>} [opts.ensureLocalStream]
    * @param {HTMLElement|null} [opts.statusEl] - recording indicator
-   * @param {function(object): void} [opts.onComplete] - after stop with payload
+   * @param {function(object): void} [opts.onComplete] - after stop (before/after upload)
+   * @param {boolean} [opts.autoUpload=true]
+   * @param {number} [opts.uploadRetries=3]
    */
   function createSessionRecorder(opts) {
     const socket = opts.socket;
@@ -65,6 +70,8 @@
       (async () => (typeof getLocalStream === "function" ? getLocalStream() : null));
     const statusEl = opts.statusEl || null;
     const onComplete = opts.onComplete || null;
+    const autoUpload = opts.autoUpload !== false;
+    const uploadRetries = typeof opts.uploadRetries === "number" ? opts.uploadRetries : 3;
 
     let mediaRecorder = null;
     let recStream = null;
@@ -72,16 +79,34 @@
     let active = false;
     let session = null; // metadata for current/last take
     let lastResult = null;
+    let pendingWork = Promise.resolve();
+    let uploadInFlight = null;
 
-    function setIndicator(text, isRecording) {
+    function setIndicator(text, mode) {
       if (!statusEl) return;
       statusEl.textContent = text;
-      statusEl.style.color = isRecording ? "#b71c1c" : "#555";
-      statusEl.style.fontWeight = isRecording ? "600" : "normal";
+      // mode: recording | uploading | ok | error | muted
+      let color = "#555";
+      let weight = "normal";
+      if (mode === "recording") {
+        color = "#b71c1c";
+        weight = "600";
+      } else if (mode === "uploading") {
+        color = "#e65100";
+        weight = "600";
+      } else if (mode === "ok") {
+        color = "#2e7d32";
+        weight = "600";
+      } else if (mode === "error") {
+        color = "#c62828";
+        weight = "600";
+      }
+      statusEl.style.color = color;
+      statusEl.style.fontWeight = weight;
     }
 
     function resetIndicator() {
-      setIndicator("", false);
+      setIndicator("", "muted");
     }
 
     function isRecording() {
@@ -90,6 +115,36 @@
 
     function getLastResult() {
       return lastResult;
+    }
+
+    function isBusy() {
+      return isRecording() || !!uploadInFlight;
+    }
+
+    /**
+     * Wait until any in-flight stop + upload chain finishes.
+     * Used before role-swap navigation / end teardown (own stem only).
+     */
+    async function waitForIdle(timeoutMs) {
+      const limit = typeof timeoutMs === "number" ? timeoutMs : 60000;
+      const start = Date.now();
+      try {
+        await pendingWork;
+      } catch (_) {
+        /* individual steps log their own errors */
+      }
+      while (isBusy() && Date.now() - start < limit) {
+        try {
+          await pendingWork;
+        } catch (_) {}
+        if (uploadInFlight) {
+          try {
+            await uploadInFlight;
+          } catch (_) {}
+        }
+        await sleep(50);
+      }
+      return { ok: !isBusy(), recording: isRecording(), uploading: !!uploadInFlight };
     }
 
     /** Debug helper: download last take as a file in the browser. */
@@ -117,6 +172,135 @@
       return true;
     }
 
+    async function uploadResult(result, attemptBase) {
+      if (!result || !result.blob) {
+        return { ok: false, reason: "no_blob" };
+      }
+      if (
+        result.client_recorder_start_ts == null ||
+        result.client_recorder_stop_ts == null ||
+        result.client_received_ts == null
+      ) {
+        setIndicator("upload blocked (missing timestamps)", "error");
+        return { ok: false, reason: "missing_timestamps" };
+      }
+
+      const attempts = uploadRetries;
+      let lastErr = null;
+
+      for (let i = 0; i < attempts; i++) {
+        if (i > 0) {
+          await sleep(400 * Math.pow(2, i - 1));
+        }
+        setIndicator(
+          i === 0 ? "↑ uploading…" : `↑ upload retry ${i + 1}/${attempts}…`,
+          "uploading"
+        );
+        try {
+          const form = new FormData();
+          const ext = (result.mimeType || "").includes("ogg")
+            ? "ogg"
+            : (result.mimeType || "").includes("mp4")
+              ? "m4a"
+              : "webm";
+          const filename = [
+            result.recording_id || "rec",
+            role,
+            participantId || "moderator",
+          ].join("_") + "." + ext;
+
+          form.append(
+            "file",
+            result.blob,
+            filename
+          );
+          form.append("game_id", result.game_id || gameId);
+          form.append("recording_id", result.recording_id || "");
+          form.append("role", role);
+          if (participantId) {
+            form.append("participant_id", participantId);
+          }
+          form.append("client_received_ts", String(result.client_received_ts));
+          form.append(
+            "client_recorder_start_ts",
+            String(result.client_recorder_start_ts)
+          );
+          form.append(
+            "client_recorder_stop_ts",
+            String(result.client_recorder_stop_ts)
+          );
+          if (result.server_ts) {
+            form.append("server_ts", result.server_ts);
+          }
+          if (result.server_stop_ts) {
+            form.append("server_stop_ts", result.server_stop_ts);
+          }
+          if (result.mimeType) {
+            form.append("mime_type", result.mimeType);
+          }
+
+          const res = await fetch("/audio/upload", {
+            method: "POST",
+            body: form,
+            credentials: "same-origin",
+            // Help survive navigation shortly after swap (best-effort).
+            keepalive: true,
+          });
+          let data = null;
+          try {
+            data = await res.json();
+          } catch (_) {
+            data = null;
+          }
+          if (!res.ok || !data || data.status !== "ok") {
+            const msg =
+              (data && data.message) || `HTTP ${res.status}`;
+            throw new Error(msg);
+          }
+
+          lastResult = {
+            ...result,
+            uploaded: true,
+            audio_path: data.audio_path,
+            audio_event_id: data.audio_event_id,
+            upload_byte_size: data.byte_size,
+          };
+          window.__lastRecording = lastResult;
+          setIndicator("✓ uploaded", "ok");
+          console.log("[Recording] uploaded", {
+            recording_id: result.recording_id,
+            audio_path: data.audio_path,
+            byte_size: data.byte_size,
+            attempt: (attemptBase || 0) + i + 1,
+          });
+          return { ok: true, data, result: lastResult };
+        } catch (err) {
+          lastErr = err;
+          console.warn("[Recording] upload attempt failed", err);
+        }
+      }
+
+      setIndicator("⚠ upload failed — use downloadLast()", "error");
+      console.error("[Recording] upload failed after retries", lastErr);
+      if (lastResult) {
+        lastResult.uploaded = false;
+        lastResult.upload_error = String(lastErr && lastErr.message || lastErr);
+      }
+      return { ok: false, reason: "upload_failed", error: lastErr };
+    }
+
+    async function runUpload(result) {
+      if (!autoUpload) {
+        return { ok: false, reason: "auto_upload_disabled" };
+      }
+      uploadInFlight = uploadResult(result);
+      try {
+        return await uploadInFlight;
+      } finally {
+        uploadInFlight = null;
+      }
+    }
+
     async function startFromEvent(data) {
       const clientReceivedTs = Date.now();
 
@@ -132,7 +316,7 @@
 
       if (typeof MediaRecorder === "undefined") {
         console.error("[Recording] MediaRecorder not supported in this browser");
-        setIndicator("recording unsupported", false);
+        setIndicator("recording unsupported", "error");
         return { ok: false, reason: "unsupported" };
       }
 
@@ -142,19 +326,19 @@
           local = await ensureLocalStream();
         } catch (err) {
           console.error("[Recording] could not get microphone stream", err);
-          setIndicator("mic required for recording", false);
+          setIndicator("mic required for recording", "error");
           return { ok: false, reason: "no_mic" };
         }
       }
       if (!local || !local.getAudioTracks().length) {
         console.error("[Recording] no local audio tracks");
-        setIndicator("mic required for recording", false);
+        setIndicator("mic required for recording", "error");
         return { ok: false, reason: "no_mic" };
       }
 
       recStream = cloneAudioStream(local);
       if (!recStream) {
-        setIndicator("mic required for recording", false);
+        setIndicator("mic required for recording", "error");
         return { ok: false, reason: "no_mic" };
       }
 
@@ -168,7 +352,7 @@
         console.error("[Recording] MediaRecorder construct failed", err);
         stopStreamTracks(recStream);
         recStream = null;
-        setIndicator("recorder error", false);
+        setIndicator("recorder error", "error");
         return { ok: false, reason: "construct_failed" };
       }
 
@@ -197,7 +381,7 @@
         mediaRecorder.start(1000);
         session.client_recorder_start_ts = Date.now();
         active = true;
-        setIndicator("⏺ recording…", true);
+        setIndicator("⏺ recording…", "recording");
         console.log("[Recording] started", {
           recording_id: session.recording_id,
           mimeType: session.mimeType,
@@ -213,13 +397,13 @@
         mediaRecorder = null;
         session = null;
         active = false;
-        setIndicator("recorder error", false);
+        setIndicator("recorder error", "error");
         return { ok: false, reason: "start_failed" };
       }
     }
 
     function stopFromEvent(data) {
-      return new Promise((resolve) => {
+      const stopPromise = new Promise((resolve) => {
         if (data && data.game_id && data.game_id !== gameId) {
           resolve({ ok: false, reason: "wrong_game" });
           return;
@@ -256,10 +440,11 @@
             blob,
             size: blob.size,
             mimeType: mime,
+            uploaded: false,
           };
           session = null;
 
-          setIndicator("recording saved (local)", false);
+          setIndicator("recording saved (local)", "muted");
           console.log("[Recording] stopped", {
             recording_id: lastResult.recording_id,
             size: lastResult.size,
@@ -277,7 +462,6 @@
             }
           }
 
-          // Expose for manual debug / next upload branch
           window.__lastRecording = lastResult;
           resolve({ ok: true, result: lastResult });
         };
@@ -295,10 +479,23 @@
           mediaRecorder = null;
           active = false;
           session = null;
-          setIndicator("recorder error", false);
+          setIndicator("recorder error", "error");
           resolve({ ok: false, reason: "stop_failed" });
         }
       });
+
+      const chain = stopPromise.then(async (stopRes) => {
+        if (stopRes && stopRes.ok && stopRes.result && autoUpload) {
+          const uploadRes = await runUpload(stopRes.result);
+          return { ...stopRes, upload: uploadRes };
+        }
+        return stopRes;
+      });
+      pendingWork = pendingWork.then(
+        () => chain,
+        () => chain
+      );
+      return chain;
     }
 
     /**
@@ -342,7 +539,7 @@
         } catch (err) {
           console.warn("[Recording] resumeIfActive poll failed", err);
         }
-        await new Promise((r) => setTimeout(r, 400));
+        await sleep(400);
       }
       return { ok: false, reason: "give_up" };
     }
@@ -391,7 +588,10 @@
       startFromEvent,
       stopFromEvent,
       resumeIfActive,
+      uploadResult,
+      waitForIdle,
       isRecording,
+      isBusy,
       getLastResult,
       downloadLast,
       resetIndicator,

--- a/static/recorder.js
+++ b/static/recorder.js
@@ -81,6 +81,9 @@
     let lastResult = null;
     let pendingWork = Promise.resolve();
     let uploadInFlight = null;
+    // After role swap this page is about to navigate; ignore round-2 recording_start
+    // so we do not block on a new take or keep chatting under the old role.
+    let suppressNewTakes = false;
 
     function setIndicator(text, mode) {
       if (!statusEl) return;
@@ -122,8 +125,24 @@
     }
 
     /**
-     * Wait until any in-flight stop + upload chain finishes.
-     * Used before role-swap navigation / end teardown (own stem only).
+     * Call before leaving the page (role swap). Stops accepting new takes and
+     * finalizes the current stem if still recording.
+     */
+    function prepareForNavigation() {
+      suppressNewTakes = true;
+      console.log("[Recording] prepareForNavigation — ignoring further starts");
+      if (isRecording()) {
+        stopFromEvent({ game_id: gameId, reason: "prepare_for_navigation" }).catch(
+          (err) => console.warn("[Recording] stop on navigate failed", err)
+        );
+      }
+    }
+
+    /**
+     * Wait until in-flight stop + upload work finishes.
+     * Does NOT wait for "not recording" — after role swap the server may start
+     * round 2 while this old page is still open; waiting for that would block
+     * navigation (and chat would keep using the old role).
      */
     async function waitForIdle(timeoutMs) {
       const limit = typeof timeoutMs === "number" ? timeoutMs : 60000;
@@ -133,18 +152,29 @@
       } catch (_) {
         /* individual steps log their own errors */
       }
-      while (isBusy() && Date.now() - start < limit) {
+      while (uploadInFlight && Date.now() - start < limit) {
+        try {
+          await uploadInFlight;
+        } catch (_) {}
         try {
           await pendingWork;
         } catch (_) {}
-        if (uploadInFlight) {
-          try {
-            await uploadInFlight;
-          } catch (_) {}
-        }
         await sleep(50);
       }
-      return { ok: !isBusy(), recording: isRecording(), uploading: !!uploadInFlight };
+      // One more drain in case stop just queued upload after pendingWork resolved.
+      try {
+        await pendingWork;
+      } catch (_) {}
+      if (uploadInFlight) {
+        try {
+          await uploadInFlight;
+        } catch (_) {}
+      }
+      return {
+        ok: !uploadInFlight,
+        recording: isRecording(),
+        uploading: !!uploadInFlight,
+      };
     }
 
     /** Debug helper: download last take as a file in the browser. */
@@ -314,6 +344,13 @@
       if (!data || data.game_id !== gameId) {
         console.log("[Recording] ignore start for other game", data && data.game_id);
         return { ok: false, reason: "wrong_game" };
+      }
+
+      if (suppressNewTakes) {
+        console.log(
+          "[Recording] ignore start — page is navigating away (role swap)"
+        );
+        return { ok: false, reason: "navigating_away" };
       }
 
       if (isRecording()) {
@@ -510,8 +547,14 @@
      * still has recording_active, start MediaRecorder for the current take.
      */
     async function resumeIfActive(maxAttempts) {
+      if (suppressNewTakes) {
+        return { ok: false, reason: "navigating_away" };
+      }
       const attempts = maxAttempts || 8;
       for (let i = 0; i < attempts; i++) {
+        if (suppressNewTakes) {
+          return { ok: false, reason: "navigating_away" };
+        }
         if (isRecording()) {
           return { ok: true, reason: "already_recording" };
         }
@@ -568,12 +611,10 @@
           stopFromEvent(data || { game_id: gameId }).catch(() => {});
         }
       });
-      // Prefer a clean stop before navigation on role swap (server also emits stop).
+      // Role swap: stop current take if needed and ignore round-2 start on this page.
       socket.on("roles_swapped", (data) => {
         if (data && data.game_id && data.game_id !== gameId) return;
-        if (isRecording()) {
-          stopFromEvent(data).catch(() => {});
-        }
+        prepareForNavigation();
       });
     }
 
@@ -597,6 +638,7 @@
       resumeIfActive,
       uploadResult,
       waitForIdle,
+      prepareForNavigation,
       isRecording,
       isBusy,
       getLastResult,

--- a/static/recorder.js
+++ b/static/recorder.js
@@ -239,12 +239,13 @@
             form.append("mime_type", result.mimeType);
           }
 
+          // Do NOT set keepalive: browsers cap keepalive bodies at ~64KB;
+          // research stems are often 0.5–several MB and would fail silently.
+          // Navigation is delayed via waitForIdle() instead.
           const res = await fetch("/audio/upload", {
             method: "POST",
             body: form,
             credentials: "same-origin",
-            // Help survive navigation shortly after swap (best-effort).
-            keepalive: true,
           });
           let data = null;
           try {
@@ -276,15 +277,21 @@
           return { ok: true, data, result: lastResult };
         } catch (err) {
           lastErr = err;
-          console.warn("[Recording] upload attempt failed", err);
+          console.warn("[Recording] upload attempt failed", {
+            attempt: i + 1,
+            size: result.size || (result.blob && result.blob.size),
+            recording_id: result.recording_id,
+            error: err && err.message ? err.message : err,
+          });
         }
       }
 
+      const errText = lastErr && lastErr.message ? lastErr.message : "unknown error";
       setIndicator("⚠ upload failed — use downloadLast()", "error");
       console.error("[Recording] upload failed after retries", lastErr);
       if (lastResult) {
         lastResult.uploaded = false;
-        lastResult.upload_error = String(lastErr && lastErr.message || lastErr);
+        lastResult.upload_error = String(errText);
       }
       return { ok: false, reason: "upload_failed", error: lastErr };
     }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -306,6 +306,14 @@
             <div id="game-links"></div>
         </div>
 
+        <div class="info-section" id="audio-stems-section" style="display: none;">
+            <h3>🎤 Audio stems (last take)</h3>
+            <p class="step-note" style="margin-top: 0;">
+                Informational only — swap/end are not blocked. Each browser uploads its own mic after stop.
+            </p>
+            <div id="audio-stems-status" style="font-family: ui-monospace, monospace; font-size: 0.95em;"></div>
+        </div>
+
         <div class="footer">
             <p>You are logged in as <strong>{{ 'Auditor (read-only)' if staff_role == 'auditor' else 'Moderator' }}</strong>.</p>
             <form action="/logout" method="get" style="display: inline;">
@@ -332,6 +340,7 @@
                         <div class="state-badge state-CLOSED">NO SESSION</div>
                         <p>${noSessionMessage}</p>
                     `;
+                    renderAudioStems(null);
                     if (staffRole !== 'auditor') {
                         updateButtons({ state: 'NO_SESSION', round_number: 1, can_swap_roles: false });
                     }
@@ -397,6 +406,8 @@
                         document.getElementById('game-links-section').style.display = 'none';
                     }
 
+                    renderAudioStems(data.last_audio_uploads);
+
                     if (staffRole !== 'auditor') {
                         updateButtons(data);
                     }
@@ -404,6 +415,37 @@
             } catch (err) {
                 console.error('Status update failed:', err);
             }
+        }
+
+        function renderAudioStems(uploads) {
+            const section = document.getElementById('audio-stems-section');
+            const el = document.getElementById('audio-stems-status');
+            if (!section || !el) return;
+
+            if (!uploads || !uploads.recording_id) {
+                section.style.display = 'none';
+                el.innerHTML = '';
+                return;
+            }
+
+            section.style.display = 'block';
+            const stems = uploads.stems || {};
+            const roles = ['player1', 'player2', 'moderator'];
+            const parts = roles.map((role) => {
+                const stem = stems[role];
+                if (stem && stem.status === 'ok') {
+                    const kb = stem.byte_size != null
+                        ? ` (${Math.round(stem.byte_size / 1024)} KB)`
+                        : '';
+                    return `<span style="color:#2e7d32;margin-right:12px;">${role} ✓${kb}</span>`;
+                }
+                return `<span style="color:#e65100;margin-right:12px;">${role} …</span>`;
+            });
+            const done = roles.filter((r) => stems[r] && stems[r].status === 'ok').length;
+            el.innerHTML = `
+                <p style="margin:0 0 8px;"><strong>recording_id:</strong> ${uploads.recording_id.substring(0, 12)}…</p>
+                <p style="margin:0;">${parts.join('')} <strong>${done}/3</strong></p>
+            `;
         }
 
         function updateButtons(statusData) {

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -307,6 +307,9 @@
                 `<em style="color: #0066cc;">⚠️ Roles swapped — uploading audio, then refreshing…</em>`,
                 "color: #0066cc; font-weight: bold;"
             );
+            if (sessionRecorder && typeof sessionRecorder.prepareForNavigation === "function") {
+                sessionRecorder.prepareForNavigation();
+            }
             if (sessionRecorder && typeof sessionRecorder.waitForIdle === "function") {
                 try {
                     await sessionRecorder.waitForIdle(60000);

--- a/templates/moderator.html
+++ b/templates/moderator.html
@@ -276,16 +276,8 @@
             setTimeout(checkEndOfGame, 100);
         });
 
-        socket.on("roles_swapped", data => {
-            console.log("Roles swapped, refreshing moderator view");
-            appendMessage(`<em style="color: #0066cc;">⚠️ Roles have been swapped! Refreshing view...</em>`, "color: #0066cc; font-weight: bold;");
-            // Reload page to show new secret card and reset grid
-            setTimeout(() => {
-                window.location.reload();
-            }, 1000);
-        });
-
         // --- Voice (WebRTC) -------------------------------------------
+        let sessionRecorder = null;
         if (!readOnly) {
             voice = setupVoice({
                 socket,
@@ -297,7 +289,7 @@
                 autoJoin: true,
             });
 
-            const sessionRecorder = createSessionRecorder({
+            sessionRecorder = createSessionRecorder({
                 socket,
                 gameId,
                 role: "moderator",
@@ -308,6 +300,22 @@
             });
             window.sessionRecorder = sessionRecorder;
         }
+
+        socket.on("roles_swapped", async data => {
+            console.log("Roles swapped, refreshing moderator view");
+            appendMessage(
+                `<em style="color: #0066cc;">⚠️ Roles swapped — uploading audio, then refreshing…</em>`,
+                "color: #0066cc; font-weight: bold;"
+            );
+            if (sessionRecorder && typeof sessionRecorder.waitForIdle === "function") {
+                try {
+                    await sessionRecorder.waitForIdle(60000);
+                } catch (err) {
+                    console.warn("waitForIdle before moderator reload failed", err);
+                }
+            }
+            window.location.reload();
+        });
     </script>
 </body>
 

--- a/templates/player1.html
+++ b/templates/player1.html
@@ -269,7 +269,10 @@
         socket.on('roles_swapped', async data => {
             if (!data || data.game_id !== gameId) return;
             appendMessage('<em>Rollen gewisseld. Audio uploaden, daarna doorsturen naar ronde 2…</em>', 'color:gray;');
-            // Wait for this browser's stop + upload before navigating (option 1 soft gate).
+            // Ignore round-2 recording_start on this old page; wait only for upload.
+            if (sessionRecorder && typeof sessionRecorder.prepareForNavigation === 'function') {
+                sessionRecorder.prepareForNavigation();
+            }
             if (sessionRecorder && typeof sessionRecorder.waitForIdle === 'function') {
                 try {
                     await sessionRecorder.waitForIdle(60000);

--- a/templates/player1.html
+++ b/templates/player1.html
@@ -126,6 +126,13 @@
 
                     if (!gameEnded) {
                         gameEnded = true;
+                        if (window.sessionRecorder && typeof window.sessionRecorder.waitForIdle === 'function') {
+                            try {
+                                await window.sessionRecorder.waitForIdle(60000);
+                            } catch (err) {
+                                console.warn('waitForIdle on game end failed', err);
+                            }
+                        }
                         if (voice) voice.stopVoice();
                         // Disable interactions
                         document.getElementById('chat-input').disabled = true;
@@ -233,12 +240,6 @@
             appendRoundCompleteMessage(data?.message || 'Einde van de ronde');
         });
 
-        socket.on('roles_swapped', data => {
-            if (!data || data.game_id !== gameId) return;
-            appendMessage('<em>Rollen gewisseld. Je wordt doorgestuurd naar ronde 2</em>', 'color:gray;');
-            setTimeout(redirectToCurrentRole, 300);
-        });
-
         // Player 1 does not receive elimination messages - only moderator and player2 should see them
 
         // --- Voice (WebRTC) -------------------------------------------
@@ -253,7 +254,7 @@
             autoJoin: true,
         });
 
-        // Local-mic capture only (separate stem per role). Upload comes later.
+        // Local-mic capture + upload on stop (own stem only).
         const sessionRecorder = createSessionRecorder({
             socket,
             gameId,
@@ -264,6 +265,20 @@
             statusEl: document.getElementById('recording-status'),
         });
         window.sessionRecorder = sessionRecorder;
+
+        socket.on('roles_swapped', async data => {
+            if (!data || data.game_id !== gameId) return;
+            appendMessage('<em>Rollen gewisseld. Audio uploaden, daarna doorsturen naar ronde 2…</em>', 'color:gray;');
+            // Wait for this browser's stop + upload before navigating (option 1 soft gate).
+            if (sessionRecorder && typeof sessionRecorder.waitForIdle === 'function') {
+                try {
+                    await sessionRecorder.waitForIdle(60000);
+                } catch (err) {
+                    console.warn('waitForIdle before role redirect failed', err);
+                }
+            }
+            redirectToCurrentRole();
+        });
     </script>
 </body>
 

--- a/templates/player2.html
+++ b/templates/player2.html
@@ -329,6 +329,9 @@
         socket.on('roles_swapped', async data => {
             if (!data || data.game_id !== gameId) return;
             appendMessage('<em>Rollen gewisseld. Audio uploaden, daarna doorsturen naar ronde 2…</em>', 'color:gray;');
+            if (sessionRecorder && typeof sessionRecorder.prepareForNavigation === 'function') {
+                sessionRecorder.prepareForNavigation();
+            }
             if (sessionRecorder && typeof sessionRecorder.waitForIdle === 'function') {
                 try {
                     await sessionRecorder.waitForIdle(60000);

--- a/templates/player2.html
+++ b/templates/player2.html
@@ -154,6 +154,13 @@
 
                     if (!gameEnded) {
                         gameEnded = true;
+                        if (window.sessionRecorder && typeof window.sessionRecorder.waitForIdle === 'function') {
+                            try {
+                                await window.sessionRecorder.waitForIdle(60000);
+                            } catch (err) {
+                                console.warn('waitForIdle on game end failed', err);
+                            }
+                        }
                         if (voice) voice.stopVoice();
                         // Disable interactions
                         document.getElementById('chat-input').disabled = true;
@@ -260,12 +267,6 @@
             setTimeout(checkEndOfGame, 100);
         });
 
-        socket.on('roles_swapped', data => {
-            if (!data || data.game_id !== gameId) return;
-            appendMessage('<em>Rollen gewisseld. Je wordt doorgestuurd naar ronde 2</em>', 'color:gray;');
-            setTimeout(redirectToCurrentRole, 300);
-        });
-
         // --- Elimination logic -----------------------------------------
         function eliminateCard(cardId) {
             const cardEl = document.getElementById(`card${cardId}`);
@@ -324,6 +325,19 @@
             statusEl: document.getElementById('recording-status'),
         });
         window.sessionRecorder = sessionRecorder;
+
+        socket.on('roles_swapped', async data => {
+            if (!data || data.game_id !== gameId) return;
+            appendMessage('<em>Rollen gewisseld. Audio uploaden, daarna doorsturen naar ronde 2…</em>', 'color:gray;');
+            if (sessionRecorder && typeof sessionRecorder.waitForIdle === 'function') {
+                try {
+                    await sessionRecorder.waitForIdle(60000);
+                } catch (err) {
+                    console.warn('waitForIdle before role redirect failed', err);
+                }
+            }
+            redirectToCurrentRole();
+        });
     </script>
 </body>
 

--- a/tests/test_audio_upload.py
+++ b/tests/test_audio_upload.py
@@ -1,0 +1,266 @@
+"""Tests for POST /audio/upload (local-mic stem storage)."""
+
+import csv
+import io
+import json
+import os
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+class TestAudioUpload:
+    def moderator_login(self, client):
+        with client.session_transaction() as sess:
+            sess["moderator"] = True
+            sess["role"] = "moderator"
+        return client
+
+    @staticmethod
+    def extract_tokens_from_csv(csv_response_data):
+        csv_content = csv_response_data.decode("utf-8")
+        csv_reader = csv.reader(io.StringIO(csv_content))
+        rows = list(csv_reader)
+        tokens = []
+        for row in rows[1:]:
+            url = row[0]
+            parsed = urlparse(url)
+            query_params = parse_qs(parsed.query)
+            token = query_params.get("token", [None])[0]
+            if token:
+                tokens.append(token)
+        return tokens
+
+    def _start_game_in_progress(self, client):
+        from app import get_game_state
+
+        self.moderator_login(client)
+        res_open = client.post("/moderator/control/open", json={})
+        game_id = json.loads(res_open.data).get("game_id")
+
+        tokens_res = client.post("/moderator/tokens/generate", json={"count": 2})
+        tokens = self.extract_tokens_from_csv(tokens_res.data)
+        client.post("/join/enter", json={"token": tokens[0]})
+        client.post("/join/enter", json={"token": tokens[1]})
+        client.post("/moderator/control/start", json={})
+
+        game_state = get_game_state(game_id)
+        assert game_state["state"] == "IN_PROGRESS"
+        return game_id, game_state
+
+    def _stem_form(self, game_id, recording_id, role, participant_id=None, **overrides):
+        data = {
+            "game_id": game_id,
+            "recording_id": recording_id,
+            "role": role,
+            "client_received_ts": "1000",
+            "client_recorder_start_ts": "1100",
+            "client_recorder_stop_ts": "2100",
+            "server_ts": "2026-07-27T12:00:00.000Z",
+            "server_stop_ts": "2026-07-27T12:01:00.000Z",
+            "mime_type": "audio/webm",
+        }
+        if participant_id:
+            data["participant_id"] = participant_id
+        data.update(overrides)
+        return data
+
+    def test_upload_requires_timestamps(self, client, reset_globals, tmp_path, monkeypatch):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, game_state = self._start_game_in_progress(client)
+        p1 = game_state["player1_id"]
+
+        res = client.post(
+            "/audio/upload",
+            data={
+                "game_id": game_id,
+                "recording_id": "rec1",
+                "role": "player1",
+                "participant_id": p1,
+            },
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 400
+        body = json.loads(res.data)
+        msg = body["message"].lower()
+        assert "client_recorder_start_ts" in msg or "required" in msg
+
+    def test_upload_rejects_wrong_participant(self, client, reset_globals, tmp_path, monkeypatch):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, _game_state = self._start_game_in_progress(client)
+
+        data = self._stem_form(game_id, "rec1", "player1", participant_id="not-a-player")
+        data["file"] = (io.BytesIO(b"fake-webm-bytes"), "stem.webm")
+        res = client.post(
+            "/audio/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 403
+
+    def test_player_upload_happy_path(self, client, reset_globals, tmp_path, monkeypatch):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, game_state = self._start_game_in_progress(client)
+        p1 = game_state["player1_id"]
+        recording_id = "abcdef0123456789"
+
+        data = self._stem_form(game_id, recording_id, "player1", participant_id=p1)
+        data["file"] = (io.BytesIO(b"fake-webm-bytes-player1"), "stem.webm")
+        res = client.post(
+            "/audio/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert res.status_code == 200, res.data
+        body = json.loads(res.data)
+        assert body["status"] == "ok"
+        assert body["recording_id"] == recording_id
+        assert body["role"] == "player1"
+        assert body["byte_size"] == len(b"fake-webm-bytes-player1")
+        assert body["audio_path"].endswith(f"{recording_id}_player1_{p1}.webm")
+
+        abs_path = os.path.join(tmp_path, body["audio_path"])
+        assert os.path.isfile(abs_path)
+        with open(abs_path, "rb") as fh:
+            assert fh.read() == b"fake-webm-bytes-player1"
+
+        with app_module.get_db_conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                """
+                SELECT recording_id, role, participant_id, byte_size, audio_path,
+                       client_recorder_start_ts, client_recorder_stop_ts
+                FROM audio_events
+                WHERE game_id = %s AND recording_id = %s AND role = %s
+                """,
+                (game_id, recording_id, "player1"),
+            )
+            row = c.fetchone()
+            assert row is not None
+            assert row["participant_id"] == p1
+            assert row["byte_size"] == len(b"fake-webm-bytes-player1")
+            assert row["client_recorder_start_ts"] == 1100
+            assert row["client_recorder_stop_ts"] == 2100
+
+        # Checklist appears on moderator status
+        status = json.loads(client.get("/moderator/control/status").data)
+        assert status["last_audio_uploads"]["recording_id"] == recording_id
+        assert status["last_audio_uploads"]["stems"]["player1"]["status"] == "ok"
+
+    def test_upload_is_idempotent(self, client, reset_globals, tmp_path, monkeypatch):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, game_state = self._start_game_in_progress(client)
+        p1 = game_state["player1_id"]
+        recording_id = "rec-idempotent"
+
+        data = self._stem_form(game_id, recording_id, "player1", participant_id=p1)
+        data["file"] = (io.BytesIO(b"first"), "stem.webm")
+        res1 = client.post("/audio/upload", data=data, content_type="multipart/form-data")
+        assert res1.status_code == 200
+
+        data2 = self._stem_form(game_id, recording_id, "player1", participant_id=p1)
+        data2["file"] = (io.BytesIO(b"second-overwrite"), "stem.webm")
+        res2 = client.post("/audio/upload", data=data2, content_type="multipart/form-data")
+        assert res2.status_code == 200
+        body = json.loads(res2.data)
+        abs_path = os.path.join(tmp_path, body["audio_path"])
+        with open(abs_path, "rb") as fh:
+            assert fh.read() == b"second-overwrite"
+
+        with app_module.get_db_conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                "SELECT COUNT(*) AS n FROM audio_events WHERE game_id=%s AND recording_id=%s AND role=%s",
+                (game_id, recording_id, "player1"),
+            )
+            assert c.fetchone()["n"] == 1
+
+    def test_moderator_upload_requires_staff_session(
+        self, client, reset_globals, tmp_path, monkeypatch
+    ):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, _game_state = self._start_game_in_progress(client)
+
+        # Clear moderator session
+        with client.session_transaction() as sess:
+            sess.clear()
+
+        data = self._stem_form(game_id, "rec-mod", "moderator")
+        data["file"] = (io.BytesIO(b"mod-bytes"), "mod.webm")
+        res = client.post("/audio/upload", data=data, content_type="multipart/form-data")
+        assert res.status_code == 403
+
+    def test_moderator_upload_happy_path(self, client, reset_globals, tmp_path, monkeypatch):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, _game_state = self._start_game_in_progress(client)
+        recording_id = "rec-mod-ok"
+
+        data = self._stem_form(game_id, recording_id, "moderator")
+        data["file"] = (io.BytesIO(b"moderator-audio"), "mod.webm")
+        res = client.post("/audio/upload", data=data, content_type="multipart/form-data")
+        assert res.status_code == 200, res.data
+        body = json.loads(res.data)
+        assert "moderator" in body["audio_path"]
+        assert os.path.isfile(os.path.join(tmp_path, body["audio_path"]))
+
+    def test_upload_after_role_swap_still_accepts_participant(
+        self, client, reset_globals, tmp_path, monkeypatch
+    ):
+        """Late upload after swap: participant is still in the game; role label is trusted."""
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, game_state = self._start_game_in_progress(client)
+        original_p1 = game_state["player1_id"]
+
+        client.post("/moderator/control/swap_roles", json={})
+        game_state = app_module.get_game_state(game_id)
+        assert game_state["player1_id"] != original_p1
+        assert original_p1 == game_state["player2_id"]
+
+        data = self._stem_form(
+            game_id, "rec-pre-swap", "player1", participant_id=original_p1
+        )
+        data["file"] = (io.BytesIO(b"late-stem"), "stem.webm")
+        res = client.post("/audio/upload", data=data, content_type="multipart/form-data")
+        assert res.status_code == 200, res.data
+
+    def test_upload_emits_socket_event(
+        self, client, socketio_client, reset_globals, tmp_path, monkeypatch
+    ):
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "AUDIO_STORAGE_DIR", str(tmp_path))
+        game_id, game_state = self._start_game_in_progress(client)
+        p1 = game_state["player1_id"]
+
+        socketio_client.emit(
+            "join",
+            {"game_id": game_id, "role": "player1", "participant_id": p1},
+        )
+        socketio_client.get_received()
+
+        data = self._stem_form(game_id, "rec-sock", "player1", participant_id=p1)
+        data["file"] = (io.BytesIO(b"sock-bytes"), "stem.webm")
+        res = client.post("/audio/upload", data=data, content_type="multipart/form-data")
+        assert res.status_code == 200
+
+        received = socketio_client.get_received()
+        events = [item for item in received if item.get("name") == "audio_upload_complete"]
+        assert len(events) == 1
+        payload = events[0]["args"][0]
+        assert payload["game_id"] == game_id
+        assert payload["role"] == "player1"
+        assert payload["recording_id"] == "rec-sock"


### PR DESCRIPTION
Fix #12 

## Summary

Completes the Phase 3 audio pipeline after MediaRecorder: each role (player1, player2, moderator) uploads its **local mic stem** when a take stops, stores it on disk, and records metadata in `audio_events`.

### Server
- `POST /audio/upload` (multipart: file + timestamps + role/game metadata)
- Storage under `AUDIO_STORAGE_DIR` (default `data/audio/`; staging e.g. `/data/xposed/shared/audio`)
- Path: `{game_id}/{recording_id}_{role}_{participant}.webm`
- Extended `audio_events` (recording_id, role, client timestamps, mime/size) with migration on startup — **no DB wipe required**
- Idempotent overwrite on `(game_id, recording_id, role)`
- Soft auth: players must be assigned to the game; moderator requires staff session (works after role swap)
- Emits `audio_upload_complete`; tracks `last_audio_uploads` in game state

### Client
- Auto-upload on every stop (manual stop, role swap, game end) with retries
- Local status: recording → uploading → ✓ uploaded / ⚠ failed (local download fallback kept)
- **Option 1 soft gate:** each browser waits for **its own** upload before swap navigation / end teardown
- Does **not** block Swap/End APIs until 3/3 stems

### Dashboard
- Informational stem checklist for the last take (`player1` / `player2` / `moderator`, n/3)
- Polls existing status endpoint; no hard gate

### Docs & tests
- ROADMAP / README / API updated
- `tests/test_audio_upload.py` for validation, auth, happy path, idempotency, post-swap upload, socket event

## Staging notes
- Set `AUDIO_STORAGE_DIR=/data/xposed/shared/audio` (recommended so stems survive releases)
- Ensure the service user can write that directory (`mkdir` + `chown`)
- Restart app so `init_db()` migrates `audio_events` columns
- Do **not** drop the database

## Test plan
- [ ] Local or staging: start game, start recording, stop → all roles show ✓ uploaded
- [ ] Files appear under `AUDIO_STORAGE_DIR/{game_id}/`
- [ ] Dashboard last-take checklist reaches 3/3 (or shows missing stems if a tab is closed)
- [ ] Role swap: round-1 stems upload before redirect; round-2 recording resumes
- [ ] End game: stems upload before teardown
- [ ] `pytest tests/test_audio_upload.py tests/test_recording_control.py`
