### PR TITLE
fix: keep session across dashboard reload; do not burn join tokens early

### DIFF
--- a/app.py
+++ b/app.py
@@ -1129,8 +1129,17 @@ def dashboard():
     """Staff dashboard."""
     if not is_staff():
         return redirect(url_for("index"))
+    # Keep moderator bound to the live session across dashboard reloads.
+    # Clearing this on every visit forced a new game_id on the next "Open"
+    # and left participants unable to join the session the UI still showed.
     if is_moderator():
-        session['moderator_session_game_id'] = None
+        current = get_current_session_game_id()
+        game_state = get_game_state(current) if current else None
+        if game_state and game_state.get("state") in ("OPEN", "READY", "IN_PROGRESS"):
+            session["moderator_session_game_id"] = current
+        else:
+            # Ended/closed sessions should not stick as "current" on the dashboard.
+            session["moderator_session_game_id"] = None
     return render_template("dashboard.html", staff_role=get_session_role())
 
 
@@ -1473,75 +1482,95 @@ def join_enter():
     if token_row['used_at']:  # used_at is not NULL
         # Token already used - reject with error
         return jsonify({"status": "error", "message": "This token has already been used and cannot be reused"}), 400
-    else:
-        # Token not yet used - generate participant_id and mark token as used
-        participant_id = str(uuid.uuid4())
-        
-        with get_db_conn() as conn:
-            c = conn.cursor()
-            # Insert participant first (foreign key constraint)
-            c.execute(
-                "INSERT INTO participants (id, created_at) VALUES (%s, %s)",
-                (participant_id, datetime.datetime.now().isoformat())
-            )
-            # Then update token with participant_id
-            c.execute(
-                "UPDATE access_tokens SET used_at = %s, participant_id = %s WHERE token = %s",
-                (datetime.datetime.now().isoformat(), participant_id, token)
-            )
-            # Context manager auto-commits
-    
+
+    # Validate session/entry BEFORE consuming the one-time token.
     current_game_id = get_current_session_game_id()
     if not current_game_id or not get_game_state(current_game_id):
         return jsonify({"status": "error", "message": "No active session"}), 400
-    
+
     game_state = get_game_state(current_game_id)
-    
+
     if game_state['state'] != 'OPEN':
         return jsonify({"status": "error", "message": "Entry is not open"}), 400
-    
-    # Add to waiting list if not already there
-    if 'waiting_participants' not in game_state:
+
+    if 'waiting_participants' not in game_state or game_state['waiting_participants'] is None:
         game_state['waiting_participants'] = []
-    
+
+    # Redis / older state may store unexpected shapes; normalise to list of dicts.
+    waiting = game_state['waiting_participants']
+    if not isinstance(waiting, list):
+        waiting = []
+        game_state['waiting_participants'] = waiting
+
+    if len(waiting) >= 2:
+        return jsonify({"status": "error", "message": "Capacity reached"}), 400
+
+    # Token not yet used - generate participant_id and mark token as used
+    participant_id = str(uuid.uuid4())
+
+    with get_db_conn() as conn:
+        c = conn.cursor()
+        # Insert participant first (foreign key constraint)
+        c.execute(
+            "INSERT INTO participants (id, created_at) VALUES (%s, %s)",
+            (participant_id, datetime.datetime.now().isoformat())
+        )
+        # Then update token with participant_id
+        c.execute(
+            "UPDATE access_tokens SET used_at = %s, participant_id = %s WHERE token = %s",
+            (datetime.datetime.now().isoformat(), participant_id, token)
+        )
+        # Context manager auto-commits
+
+    # Re-load state after DB work in case another joiner raced us.
+    game_state = get_game_state(current_game_id) or game_state
+    if game_state.get('state') != 'OPEN':
+        return jsonify({"status": "error", "message": "Entry is not open"}), 400
+    if 'waiting_participants' not in game_state or not isinstance(game_state['waiting_participants'], list):
+        game_state['waiting_participants'] = []
+
     # Check if participant is already in waiting list
-    if any(p['id'] == participant_id for p in game_state['waiting_participants']):
+    if any(
+        (p.get('id') if isinstance(p, dict) else p) == participant_id
+        for p in game_state['waiting_participants']
+    ):
         return jsonify({
             "status": "ok",
             "participant_id": participant_id,
-            "waiting_count": len(game_state['waiting_participants'])
+            "waiting_count": len(game_state['waiting_participants']),
+            "game_id": current_game_id,
         })
-    
+
     if len(game_state['waiting_participants']) >= 2:
         return jsonify({"status": "error", "message": "Capacity reached"}), 400
-    
+
     game_state['waiting_participants'].append({
         'id': participant_id,
         'timestamp': datetime.datetime.now().isoformat()
     })
-    
+
     print(f"Participant {participant_id} entered waiting room. Count: {len(game_state['waiting_participants'])}/2")
-    
+
     # Auto-close if capacity reached
     if len(game_state['waiting_participants']) == 2:
         game_state['state'] = 'READY'
         # Assign roles
         game_state['player1_id'] = game_state['waiting_participants'][0]['id']
         game_state['player2_id'] = game_state['waiting_participants'][1]['id']
-        
+
         # Save updated state to Redis
         set_game_state(current_game_id, game_state)
-        
+
         # Bind roles in database
         set_participant_binding(current_game_id, game_state['player1_id'], 'player1', round_number=1)
         set_participant_binding(current_game_id, game_state['player2_id'], 'player2', round_number=1)
-        
+
         record_event("system", "entry_closed", current_game_id, text="Capacity reached (2/2)")
         print(f"Game {current_game_id} ready with 2 participants")
     else:
         # Save updated state to Redis
         set_game_state(current_game_id, game_state)
-    
+
     return jsonify({
         "status": "ok",
         "participant_id": participant_id,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -621,9 +621,13 @@
                     `;
 
                     if (data.state === 'OPEN') {
-                        statusHtml += `<p>✅ Toegang is open — ${data.waiting_count}/2 deelnemers wachten</p>`;
+                        const waiting = data.waiting_count || 0;
+                        statusHtml += `<p>✅ Toegang is open — <strong>${waiting}/2</strong> deelnemers in de wachtruimte</p>`;
+                        if (waiting < 2) {
+                            statusHtml += `<p style="color:#64748b;margin-top:6px;">Wacht tot beide deelnemers via hun tokenlink op „Meedoen” klikken (microfoon eerst controleren). „Spel starten” wordt pas actief bij 2/2.</p>`;
+                        }
                     } else if (data.state === 'READY') {
-                        statusHtml += `<p>⏳ 2 deelnemers klaar — klik op „Spel starten”</p>`;
+                        statusHtml += `<p>⏳ 2 deelnemers klaar — controleer je microfoon en klik op „Spel starten”</p>`;
                     } else if (data.state === 'IN_PROGRESS') {
                         statusHtml += `<p>🎮 Spel bezig (ronde ${data.round_number || 1})`;
                         if (data.recording_active) {

--- a/tests/test_session_join_admission.py
+++ b/tests/test_session_join_admission.py
@@ -1,0 +1,160 @@
+"""Regression tests for session stickiness and token consumption on join."""
+
+import csv
+import io
+import json
+from urllib.parse import parse_qs, urlparse
+
+
+class TestSessionJoinAdmission:
+    """Bugs: dashboard reload cleared session; join burned tokens when entry closed."""
+
+    def moderator_login(self, client):
+        with client.session_transaction() as sess:
+            sess["moderator"] = True
+            sess["role"] = "moderator"
+        return client
+
+    @staticmethod
+    def extract_tokens_from_csv(csv_response_data):
+        csv_content = csv_response_data.decode("utf-8")
+        csv_reader = csv.reader(io.StringIO(csv_content))
+        rows = list(csv_reader)
+        tokens = []
+        for row in rows[1:]:
+            url = row[0]
+            parsed = urlparse(url)
+            query_params = parse_qs(parsed.query)
+            token = query_params.get("token", [None])[0]
+            if token:
+                tokens.append(token)
+        return tokens
+
+    @staticmethod
+    def token_used_at(token):
+        from app import get_db_conn
+
+        with get_db_conn() as conn:
+            c = conn.cursor()
+            c.execute(
+                "SELECT used_at FROM access_tokens WHERE token = %s",
+                (token,),
+            )
+            row = c.fetchone()
+            return row["used_at"] if row else "missing"
+
+    def test_dashboard_reload_keeps_open_session_game_id(self, client, reset_globals):
+        """Reloading /dashboard must not drop moderator_session_game_id for OPEN games."""
+        from app import get_game_state
+
+        self.moderator_login(client)
+        res_open = client.post("/moderator/control/open", json={})
+        assert res_open.status_code == 200
+        game_id = json.loads(res_open.data)["game_id"]
+        assert get_game_state(game_id)["state"] == "OPEN"
+
+        # Visiting the dashboard previously cleared the session binding.
+        res_dash = client.get("/dashboard")
+        assert res_dash.status_code == 200
+
+        with client.session_transaction() as sess:
+            assert sess.get("moderator_session_game_id") == game_id
+
+        # Status and a second "open" must stay on the same game.
+        status = json.loads(client.get("/moderator/control/status").data)
+        assert status["status"] == "ok"
+        assert status["game_id"] == game_id
+        assert status["state"] == "OPEN"
+
+        res_open2 = client.post("/moderator/control/open", json={})
+        assert res_open2.status_code == 200
+        assert json.loads(res_open2.data)["game_id"] == game_id
+        assert get_game_state(game_id)["state"] == "OPEN"
+
+    def test_dashboard_reload_keeps_ready_session(self, client, reset_globals):
+        """READY sessions must also survive dashboard reload (pre-start)."""
+        from app import get_game_state
+
+        self.moderator_login(client)
+        game_id = json.loads(client.post("/moderator/control/open", json={}).data)[
+            "game_id"
+        ]
+        tokens = self.extract_tokens_from_csv(
+            client.post("/moderator/tokens/generate", json={"count": 2}).data
+        )
+        client.post("/join/enter", json={"token": tokens[0]})
+        client.post("/join/enter", json={"token": tokens[1]})
+        assert get_game_state(game_id)["state"] == "READY"
+
+        assert client.get("/dashboard").status_code == 200
+        with client.session_transaction() as sess:
+            assert sess.get("moderator_session_game_id") == game_id
+
+        status = json.loads(client.get("/moderator/control/status").data)
+        assert status["game_id"] == game_id
+        assert status["state"] == "READY"
+
+    def test_join_without_open_session_does_not_consume_token(
+        self, client, reset_globals
+    ):
+        """Token must remain reusable if join fails because there is no OPEN entry."""
+        self.moderator_login(client)
+        # Tokens do not require an open session; join does.
+        tokens = self.extract_tokens_from_csv(
+            client.post("/moderator/tokens/generate", json={"count": 1}).data
+        )
+        token = tokens[0]
+        assert self.token_used_at(token) is None
+
+        res = client.post("/join/enter", json={"token": token})
+        assert res.status_code == 400
+        data = json.loads(res.data)
+        assert data["status"] == "error"
+        assert "session" in data["message"].lower() or "open" in data["message"].lower()
+
+        # Critical: token still unused
+        assert self.token_used_at(token) is None
+
+        # After opening entry, same token must work
+        open_res = client.post("/moderator/control/open", json={})
+        assert open_res.status_code == 200
+        join_res = client.post("/join/enter", json={"token": token})
+        assert join_res.status_code == 200
+        assert json.loads(join_res.data)["status"] == "ok"
+        assert self.token_used_at(token) is not None
+
+    def test_join_when_entry_not_open_does_not_consume_token(
+        self, client, reset_globals
+    ):
+        """If session exists but is not OPEN, failed join must not burn the token."""
+        from app import get_game_state, set_game_state
+
+        self.moderator_login(client)
+        game_id = json.loads(client.post("/moderator/control/open", json={}).data)[
+            "game_id"
+        ]
+        tokens = self.extract_tokens_from_csv(
+            client.post("/moderator/tokens/generate", json={"count": 1}).data
+        )
+        token = tokens[0]
+
+        # Force closed entry while session id is still current
+        state = get_game_state(game_id)
+        state["state"] = "CLOSED"
+        set_game_state(game_id, state)
+
+        res = client.post("/join/enter", json={"token": token})
+        assert res.status_code == 400
+        assert "open" in json.loads(res.data)["message"].lower()
+        assert self.token_used_at(token) is None
+
+        # Re-open and use the same token
+        state = get_game_state(game_id)
+        state["state"] = "OPEN"
+        state["waiting_participants"] = []
+        set_game_state(game_id, state)
+
+        join_res = client.post("/join/enter", json={"token": token})
+        assert join_res.status_code == 200
+        assert json.loads(join_res.data)["status"] == "ok"
+        assert self.token_used_at(token) is not None


### PR DESCRIPTION
## Summary
Fixes two long-standing admission bugs that made it look like players could not join after **Toegang openen** (especially after dashboard reloads while testing).

1. Visiting `/dashboard` no longer clears `moderator_session_game_id` for live OPEN/READY/IN_PROGRESS sessions. Reloading the dashboard and clicking open again no longer creates a new `game_id` and orphans waiters.
2. `/join/enter` validates that entry is OPEN (and a session exists) **before** marking a one-time token as used, so failed joins do not burn invitation links.
3. **Tests** — Regression coverage in `tests/test_session_join_admission.py`.

## Test plan
- [ ] Open entry → reload dashboard → status still same game, OPEN; open again does not change `game_id`
- [ ] Two players join with fresh tokens → READY → Start works
- [ ] Join **before** open fails; same token still works after open
- [ ] `pytest tests/test_session_join_admission.py -q`
- [ ] Optional: full session smoke (open → 2 join → start)